### PR TITLE
Move heavy operations off MainActor to prevent UI blocking.

### DIFF
--- a/Dictate Anywhere/Services/SettingsManager.swift
+++ b/Dictate Anywhere/Services/SettingsManager.swift
@@ -22,6 +22,9 @@ final class SettingsManager {
 
     static let shared = SettingsManager()
 
+    /// Background queue for sound playback to avoid blocking MainActor
+    private let soundQueue = DispatchQueue(label: "com.dictate-anywhere.sounds", qos: .userInteractive)
+
     // MARK: - UserDefaults Keys
 
     private enum Keys {
@@ -252,12 +255,16 @@ final class SettingsManager {
 
     // MARK: - Methods
 
-    /// Plays a sound effect if enabled, with the configured volume
+    /// Plays a sound effect if enabled, with the configured volume (runs off MainActor)
     func playSound(_ name: String) {
         guard soundEffectsEnabled else { return }
-        guard let sound = NSSound(named: name) else { return }
-        sound.volume = soundEffectsVolume
-        sound.play()
+        let volume = soundEffectsVolume
+
+        soundQueue.async {
+            guard let sound = NSSound(named: name) else { return }
+            sound.volume = volume
+            sound.play()
+        }
     }
 
     /// Clears the custom shortcut

--- a/Dictate Anywhere/ViewModels/DictationViewModel.swift
+++ b/Dictate Anywhere/ViewModels/DictationViewModel.swift
@@ -258,8 +258,8 @@ final class DictationViewModel {
     }
 
     private func performSetup() async {
-        // Check permissions
-        permissionChecker.checkPermissions()
+        // Check permissions (runs off MainActor)
+        await permissionChecker.checkPermissionsAsync()
 
         // If permissions missing, show permissions screen
         if !permissionChecker.allPermissionsGranted {
@@ -267,8 +267,8 @@ final class DictationViewModel {
             return
         }
 
-        // Check if model already exists on disk
-        let modelExistsOnDisk = modelManager.checkModelExistsOnDisk()
+        // Check if model already exists on disk (runs off MainActor)
+        let modelExistsOnDisk = await modelManager.checkModelExistsOnDisk()
 
         // Show appropriate state based on whether model needs downloading
         if modelExistsOnDisk {


### PR DESCRIPTION
Changes:
- FluidModelManager: File system checks now run on background queue
  - init() uses cached UserDefaults value, verifies in background
  - checkModelExistsOnDisk() is now async
  - deleteModelFiles() is now async
  - cleanupOldWhisperKitModels runs in background

- MicrophoneManager: CoreAudio queries now run on background queue
  - init() refreshes microphones in background
  - refreshMicrophones() dispatches to background queue
  - Device change listener uses background refresh

- PermissionChecker: Permission checks now run on background queue
  - init() checks permissions in background
  - Added checkPermissionsAsync() for awaitable checks
  - AXIsProcessTrusted and AVCaptureDevice.authorizationStatus run off main

- SettingsManager: Sound playback now runs on background queue
  - playSound() loads and plays sounds off MainActor

- DictationViewModel: Updated to use new async APIs
  - Uses await checkModelExistsOnDisk()
  - Uses await checkPermissionsAsync()

These changes prevent the main thread from blocking during:
- App startup (file checks, permission checks, device enumeration)
- Sound playback during dictation start/stop