### PR TITLE
Add security-related files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,20 @@ Thumbs.db
 
 # Distribution
 dist/
+sparkle-releases/
+
+# Secrets / signing keys / certificates (defense-in-depth)
+*.pem
+*.p12
+*.p8
+*.key
+*.cer
+*.pfx
+*.keystore
+*.mobileprovision
+*.provisionprofile
+.env
+.env.*
 
 # User-specific xcconfig files
 *.xcconfig


### PR DESCRIPTION
## Summary
Enhanced the `.gitignore` file to prevent accidental commits of sensitive security artifacts and environment configuration files.

## Key Changes
- Added `sparkle-releases/` directory to ignore Sparkle framework release artifacts
- Added comprehensive patterns for cryptographic and signing materials:
  - Certificate files (`.pem`, `.cer`)
  - Private keys (`.key`, `.p8`, `.p12`, `.pfx`)
  - Keystore files (`.keystore`)
  - iOS provisioning profiles (`.mobileprovision`, `.provisionprofile`)
- Added environment variable files (`.env`, `.env.*`) to prevent leaking secrets

## Implementation Details
These additions follow defense-in-depth security practices by ensuring that sensitive files such as private keys, certificates, and environment configurations are never accidentally committed to version control, regardless of their location in the repository.

https://claude.ai/code/session_01AaMdiUfauJwiZW398Awyd5