### PR TITLE
Auto-switch speech model and language with the keyboard input source

### DIFF
--- a/Dictate Anywhere.xcodeproj/xcshareddata/xcschemes/Dictate Anywhere.xcscheme
+++ b/Dictate Anywhere.xcodeproj/xcshareddata/xcschemes/Dictate Anywhere.xcscheme
@@ -29,6 +29,13 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "RUN_MODEL_SWITCH_BENCHMARK"
+            value = "$(RUN_MODEL_SWITCH_BENCHMARK)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -53,6 +60,11 @@
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "RUN_MODEL_SWITCH_BENCHMARK"
+            value = "$(RUN_MODEL_SWITCH_BENCHMARK)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
          <EnvironmentVariable
             key = "RUN_MANDARIN_ASR_TESTS"
             value = "$(RUN_MANDARIN_ASR_TESTS)"

--- a/Dictate Anywhere/AppState.swift
+++ b/Dictate Anywhere/AppState.swift
@@ -388,6 +388,16 @@ final class AppState {
                 settings.noteAutoSwitchModelChange(hadVocabularyMode: hadVocabularyMode)
                 settings.restoreVocabularyModeAfterAutoSwitchIfPending()
             case .appleSpeech:
+                // Pin the language before the engine switch: handleEngineSelectionChange
+                // calls prepareActiveEngine(), which prepares Apple Speech using
+                // whatever Settings.shared.appleSpeechLanguage currently holds. If
+                // that's stale (e.g. left over from a cancelled download), the first
+                // prepare would silently download assets for the wrong, uninstalled
+                // language even though the resolver already gated on the mapped
+                // language's assets being installed. Writing it first — synchronously,
+                // before any await in this arm — makes the first prepare already
+                // target the gated language.
+                settings.appleSpeechLanguage = mapping.language
                 await handleEngineSelectionChange(.appleSpeech)
                 await handleAppleSpeechLanguageChange(mapping.language)
             }

--- a/Dictate Anywhere/AppState.swift
+++ b/Dictate Anywhere/AppState.swift
@@ -315,8 +315,15 @@ final class AppState {
     }
 
     func applyInputSourceProfile(for inputSourceID: String, showLoadingOverlay: Bool = false) async {
-        guard status == .idle else { return }
+        // Looked up (and, for Apple Speech, awaited) before the idle guard so
+        // no suspension point lands between the guard and the settings
+        // writes below — an in-flight recording-start guard check must never
+        // race a suspended apply.
         let mapping = settings.mapping(forInputSourceID: inputSourceID)
+        let installedAppleSpeechLanguages = mapping?.engine == .appleSpeech
+            ? await AppleSpeechEngine.installedLanguages()
+            : []
+        guard status == .idle else { return }
         let resolution = InputSourceProfileResolver.resolve(
             mapping: mapping,
             enabled: settings.inputSourceAutoSwitchEnabled,
@@ -325,7 +332,8 @@ final class AppState {
             currentFluidAudioLanguage: settings.selectedLanguage,
             currentAppleSpeechLanguage: settings.appleSpeechLanguage,
             appleSpeechSupported: AppleSpeechEngine.isSupported,
-            isModelDownloaded: { parakeetEngine.checkModelOnDisk(for: $0) }
+            isModelDownloaded: { parakeetEngine.checkModelOnDisk(for: $0) },
+            isAppleSpeechAssetInstalled: { installedAppleSpeechLanguages.contains($0) }
         )
 
         var targetEngine = "n/a"

--- a/Dictate Anywhere/AppState.swift
+++ b/Dictate Anywhere/AppState.swift
@@ -399,18 +399,19 @@ final class AppState {
                 settings.noteAutoSwitchModelChange(hadVocabularyMode: hadVocabularyMode)
                 settings.restoreVocabularyModeAfterAutoSwitchIfPending()
             case .appleSpeech:
-                // Pin the language before the engine switch: handleEngineSelectionChange
-                // calls prepareActiveEngine(), which prepares Apple Speech using
-                // whatever Settings.shared.appleSpeechLanguage currently holds. If
-                // that's stale (e.g. left over from a cancelled download), the first
-                // prepare would silently download assets for the wrong, uninstalled
-                // language even though the resolver already gated on the mapped
-                // language's assets being installed. Writing it first — synchronously,
-                // before any await in this arm — makes the first prepare already
-                // target the gated language.
+                // Pin the language before the engine switch so the one and only
+                // prepare targets the gated, installed language (a stale
+                // appleSpeechLanguage would otherwise download the wrong
+                // assets). The explicit invalidate matters: a session prepared
+                // earlier for a different language would satisfy the isReady
+                // check in prepareActiveEngine and skip preparation entirely.
+                // handleEngineSelectionChange only invalidates when switching
+                // AWAY from Apple Speech, so it won't double-invalidate here,
+                // and no second language-change call is needed — that was the
+                // duplicate-preparation path.
                 settings.appleSpeechLanguage = mapping.language
+                await appleSpeechEngine.invalidatePreparedSession()
                 await handleEngineSelectionChange(.appleSpeech)
-                await handleAppleSpeechLanguageChange(mapping.language)
             }
             if showLoadingOverlay { overlay.hide(afterDelay: 0) }
         }

--- a/Dictate Anywhere/AppState.swift
+++ b/Dictate Anywhere/AppState.swift
@@ -258,6 +258,12 @@ final class AppState {
             }
             logger.info("prepareActiveEngine: prepare() completed, isReady=\(self.activeEngine.isReady, privacy: .public)")
         }
+        // A just-completed prepare may have installed the Apple Speech asset
+        // the input-source mapping hint is watching; refresh so the hint
+        // clears without waiting for settings to reopen.
+        if settings.engineChoice == .appleSpeech {
+            appleSpeechInstalledLanguages = await AppleSpeechEngine.installedLanguages()
+        }
         isPreparingEngine = false
     }
 

--- a/Dictate Anywhere/AppState.swift
+++ b/Dictate Anywhere/AppState.swift
@@ -339,7 +339,14 @@ final class AppState {
         )
 
         switch resolution {
-        case .none, .noChange, .inactive:
+        case .none, .inactive:
+            return
+
+        case .noChange:
+            // A source mapped to the already-active vocab-capable model must
+            // still trigger the restore (e.g. a prior switch away stripped
+            // `.fluidAudioVocabulary` and this source maps back to it).
+            settings.restoreVocabularyModeAfterAutoSwitchIfPending()
             return
 
         case .languageOnly(let language):
@@ -353,6 +360,7 @@ final class AppState {
                 await handleAppleSpeechLanguageChange(language)
                 if showLoadingOverlay { overlay.hide(afterDelay: 0) }
             }
+            settings.restoreVocabularyModeAfterAutoSwitchIfPending()
 
         case .fullApply:
             guard let mapping else { return }
@@ -363,11 +371,14 @@ final class AppState {
             switch mapping.engine {
             case .parakeet:
                 guard let model = mapping.parakeetModel else { break }
+                let hadVocabularyMode = settings.transcriptPostProcessingMode == .fluidAudioVocabulary
                 // Model before language: the model didSet coerces unsupported
                 // languages back to English.
                 settings.parakeetModelChoice = model
                 settings.selectedLanguage = mapping.language
                 await handleParakeetModelSelectionChange(userInitiated: true)
+                settings.noteAutoSwitchModelChange(hadVocabularyMode: hadVocabularyMode)
+                settings.restoreVocabularyModeAfterAutoSwitchIfPending()
             case .appleSpeech:
                 await handleEngineSelectionChange(.appleSpeech)
                 await handleAppleSpeechLanguageChange(mapping.language)

--- a/Dictate Anywhere/AppState.swift
+++ b/Dictate Anywhere/AppState.swift
@@ -332,7 +332,9 @@ final class AppState {
             currentFluidAudioLanguage: settings.selectedLanguage,
             currentAppleSpeechLanguage: settings.appleSpeechLanguage,
             appleSpeechSupported: AppleSpeechEngine.isSupported,
-            isModelDownloaded: { parakeetEngine.checkModelOnDisk(for: $0) },
+            // Availability = on disk AND runnable by this process (FluidAudio
+            // hard-fails Nemotron multilingual under Rosetta/x86_64).
+            isModelDownloaded: { parakeetEngine.checkModelOnDisk(for: $0) && $0.isAvailableOnThisMac },
             isAppleSpeechAssetInstalled: { installedAppleSpeechLanguages.contains($0) }
         )
 

--- a/Dictate Anywhere/AppState.swift
+++ b/Dictate Anywhere/AppState.swift
@@ -183,7 +183,7 @@ final class AppState {
         inputSourceMonitor.startMonitoring()
         if settings.inputSourceAutoSwitchEnabled,
            let inputSourceID = inputSourceMonitor.currentInputSourceID() {
-            await applyInputSourceProfile(for: inputSourceID)
+            await enqueueInputSourceProfileApply(for: inputSourceID).value
         }
     }
 
@@ -295,8 +295,13 @@ final class AppState {
 
     // MARK: - Input Source Auto-Switch
 
+    /// Serializes calls to `applyInputSourceProfile` so overlapping input
+    /// source changes apply in order. Internal (not private) so callers
+    /// outside AppState — e.g. the startup sequence and settings UI — also
+    /// go through the queue instead of calling `applyInputSourceProfile`
+    /// directly.
     @discardableResult
-    private func enqueueInputSourceProfileApply(
+    func enqueueInputSourceProfileApply(
         for inputSourceID: String,
         showLoadingOverlay: Bool = false
     ) -> Task<Void, Never> {
@@ -323,12 +328,23 @@ final class AppState {
             isModelDownloaded: { parakeetEngine.checkModelOnDisk(for: $0) }
         )
 
+        var targetEngine = "n/a"
+        var targetModel = "n/a"
+        if case .fullApply = resolution, let mapping {
+            targetEngine = mapping.engine.rawValue
+            targetModel = mapping.parakeetModel?.rawValue ?? "n/a"
+        }
+        logger.info(
+            "applyInputSourceProfile: inputSourceID=\(inputSourceID, privacy: .public), resolution=\(String(describing: resolution), privacy: .public), targetEngine=\(targetEngine, privacy: .public), targetModel=\(targetModel, privacy: .public)"
+        )
+
         switch resolution {
         case .none, .noChange, .inactive:
             return
 
         case .languageOnly(let language):
-            switch settings.engineChoice {
+            guard let mapping else { return }
+            switch mapping.engine {
             case .parakeet:
                 // Read at recording start; no engine reload needed.
                 settings.selectedLanguage = language

--- a/Dictate Anywhere/AppState.swift
+++ b/Dictate Anywhere/AppState.swift
@@ -61,6 +61,7 @@ final class AppState {
     let audioDeviceManager = AudioDeviceManager()
     let parakeetEngine = ParakeetEngine()
     let appleSpeechEngine = AppleSpeechEngine()
+    let inputSourceMonitor = InputSourceMonitor()
     var appleSpeechSupportedLanguages: [SupportedLanguage] = []
     private var isShowingMigrationAlert = false
 
@@ -86,6 +87,9 @@ final class AppState {
     private var startupTask: Task<Void, Never>?
     private var hasStarted = false
 
+    /// Serializes profile applies; a change arriving mid-apply queues behind it.
+    private var inputSourceApplyTask: Task<Void, Never>?
+
     // MARK: - Active Engine
 
     var activeEngine: TranscriptionEngine {
@@ -106,6 +110,7 @@ final class AppState {
     init() {
         setupHotkeyCallbacks()
         setupPermissionCallbacks()
+        setupInputSourceCallbacks()
     }
 
     // MARK: - Hotkey Callbacks
@@ -156,6 +161,12 @@ final class AppState {
         }
     }
 
+    private func setupInputSourceCallbacks() {
+        inputSourceMonitor.onSelectedInputSourceChanged = { [weak self] inputSourceID in
+            self?.enqueueInputSourceProfileApply(for: inputSourceID)
+        }
+    }
+
     func start() {
         guard !hasStarted else { return }
         hasStarted = true
@@ -169,6 +180,11 @@ final class AppState {
         await permissions.check()
         updateAccessibilityIntegration(granted: permissions.accessibilityGranted, promptIfNeeded: true)
         await prepareActiveEngine()
+        inputSourceMonitor.startMonitoring()
+        if settings.inputSourceAutoSwitchEnabled,
+           let inputSourceID = inputSourceMonitor.currentInputSourceID() {
+            await applyInputSourceProfile(for: inputSourceID)
+        }
     }
 
     private func handleAccessibilityPermissionChanged(_ granted: Bool) {
@@ -277,6 +293,73 @@ final class AppState {
         appleSpeechSupportedLanguages = await AppleSpeechEngine.supportedLanguages()
     }
 
+    // MARK: - Input Source Auto-Switch
+
+    @discardableResult
+    private func enqueueInputSourceProfileApply(
+        for inputSourceID: String,
+        showLoadingOverlay: Bool = false
+    ) -> Task<Void, Never> {
+        let previous = inputSourceApplyTask
+        let task = Task { [weak self] in
+            await previous?.value
+            await self?.applyInputSourceProfile(for: inputSourceID, showLoadingOverlay: showLoadingOverlay)
+        }
+        inputSourceApplyTask = task
+        return task
+    }
+
+    func applyInputSourceProfile(for inputSourceID: String, showLoadingOverlay: Bool = false) async {
+        guard status == .idle else { return }
+        let mapping = settings.mapping(forInputSourceID: inputSourceID)
+        let resolution = InputSourceProfileResolver.resolve(
+            mapping: mapping,
+            enabled: settings.inputSourceAutoSwitchEnabled,
+            currentEngine: settings.engineChoice,
+            currentParakeetModel: settings.parakeetModelChoice,
+            currentFluidAudioLanguage: settings.selectedLanguage,
+            currentAppleSpeechLanguage: settings.appleSpeechLanguage,
+            appleSpeechSupported: AppleSpeechEngine.isSupported,
+            isModelDownloaded: { parakeetEngine.checkModelOnDisk(for: $0) }
+        )
+
+        switch resolution {
+        case .none, .noChange, .inactive:
+            return
+
+        case .languageOnly(let language):
+            switch settings.engineChoice {
+            case .parakeet:
+                // Read at recording start; no engine reload needed.
+                settings.selectedLanguage = language
+            case .appleSpeech:
+                if showLoadingOverlay { overlay.show(state: .preparingModel(name: "Apple Speech")) }
+                await handleAppleSpeechLanguageChange(language)
+                if showLoadingOverlay { overlay.hide(afterDelay: 0) }
+            }
+
+        case .fullApply:
+            guard let mapping else { return }
+            let profileName = mapping.engine == .parakeet
+                ? (mapping.parakeetModel?.displayName ?? "model")
+                : "Apple Speech"
+            if showLoadingOverlay { overlay.show(state: .preparingModel(name: profileName)) }
+            switch mapping.engine {
+            case .parakeet:
+                guard let model = mapping.parakeetModel else { break }
+                // Model before language: the model didSet coerces unsupported
+                // languages back to English.
+                settings.parakeetModelChoice = model
+                settings.selectedLanguage = mapping.language
+                await handleParakeetModelSelectionChange(userInitiated: true)
+            case .appleSpeech:
+                await handleEngineSelectionChange(.appleSpeech)
+                await handleAppleSpeechLanguageChange(mapping.language)
+            }
+            if showLoadingOverlay { overlay.hide(afterDelay: 0) }
+        }
+    }
+
     // MARK: - Ollama Model Management
 
     func startOllamaModelDownload(_ model: String) async {
@@ -351,6 +434,12 @@ final class AppState {
             status = .idle
         }
         guard status == .idle, !isTransitioning else { return }
+        if settings.inputSourceAutoSwitchEnabled,
+           let inputSourceID = inputSourceMonitor.currentInputSourceID() {
+            // Backstop: the eager pre-warm usually already did this; going
+            // through the queue serializes against an apply still in flight.
+            await enqueueInputSourceProfileApply(for: inputSourceID, showLoadingOverlay: true).value
+        }
         let engine = activeEngine
         switch settings.engineChoice {
         case .parakeet:

--- a/Dictate Anywhere/AppState.swift
+++ b/Dictate Anywhere/AppState.swift
@@ -63,6 +63,7 @@ final class AppState {
     let appleSpeechEngine = AppleSpeechEngine()
     let inputSourceMonitor = InputSourceMonitor()
     var appleSpeechSupportedLanguages: [SupportedLanguage] = []
+    var appleSpeechInstalledLanguages: [SupportedLanguage] = []
     private var isShowingMigrationAlert = false
 
     /// Whether the app is transitioning between states (simple guard)
@@ -180,6 +181,7 @@ final class AppState {
         await permissions.check()
         updateAccessibilityIntegration(granted: permissions.accessibilityGranted, promptIfNeeded: true)
         await prepareActiveEngine()
+        await refreshAppleSpeechAssetState()
         inputSourceMonitor.startMonitoring()
         if settings.inputSourceAutoSwitchEnabled,
            let inputSourceID = inputSourceMonitor.currentInputSourceID() {
@@ -228,7 +230,7 @@ final class AppState {
                 settings.legacyAppleSpeechMigrationPending = false
             }
         case .appleSpeech:
-            await refreshAppleSpeechLanguages()
+            await refreshAppleSpeechAssetState()
             if !appleSpeechSupportedLanguages.contains(settings.appleSpeechLanguage),
                let fallback = appleSpeechSupportedLanguages.first {
                 settings.appleSpeechLanguage = fallback
@@ -289,8 +291,12 @@ final class AppState {
         await prepareActiveEngine()
     }
 
-    private func refreshAppleSpeechLanguages() async {
+    /// Refreshes both the supportable and the installed Apple Speech language
+    /// sets. Installed state drives the input-source mapping UI, so it must be
+    /// fresh even while FluidAudio is the active engine.
+    func refreshAppleSpeechAssetState() async {
         appleSpeechSupportedLanguages = await AppleSpeechEngine.supportedLanguages()
+        appleSpeechInstalledLanguages = await AppleSpeechEngine.installedLanguages()
     }
 
     // MARK: - Input Source Auto-Switch
@@ -324,6 +330,9 @@ final class AppState {
             ? await AppleSpeechEngine.installedLanguages()
             : []
         guard status == .idle else { return }
+        if mapping?.engine == .appleSpeech {
+            appleSpeechInstalledLanguages = installedAppleSpeechLanguages
+        }
         let resolution = InputSourceProfileResolver.resolve(
             mapping: mapping,
             enabled: settings.inputSourceAutoSwitchEnabled,

--- a/Dictate Anywhere/AppleSpeechEngine.swift
+++ b/Dictate Anywhere/AppleSpeechEngine.swift
@@ -244,6 +244,30 @@ final class AppleSpeechEngine: TranscriptionEngine {
         return result
     }
 
+    /// Languages whose on-device Speech assets are already installed —
+    /// distinct from `supportedLanguages()`, which only reports what the
+    /// framework *could* support. Auto-switching must never trigger a
+    /// silent asset download, so callers use this to gate mappings that
+    /// would otherwise call through to `prepare()`.
+    static func installedLanguages() async -> [SupportedLanguage] {
+        guard Self.isSupported else { return [] }
+        guard #available(macOS 26.0, *) else { return [] }
+
+        let installedLocales = await SpeechTranscriber.installedLocales
+        let installedIdentifiers = Set(installedLocales.map { $0.identifier(.bcp47) })
+
+        var result: [SupportedLanguage] = []
+        for language in SupportedLanguage.allCases {
+            guard let canonical = await SpeechTranscriber.supportedLocale(equivalentTo: locale(for: language)) else {
+                continue
+            }
+            if installedIdentifiers.contains(canonical.identifier(.bcp47)) {
+                result.append(language)
+            }
+        }
+        return result
+    }
+
     private func appleContextualVocabulary() -> [String] {
         guard Settings.shared.fluidAudioVocabularyEnabled else { return [] }
         return Settings.shared.customVocabulary

--- a/Dictate Anywhere/InputSourceMonitor.swift
+++ b/Dictate Anywhere/InputSourceMonitor.swift
@@ -1,0 +1,116 @@
+//
+//  InputSourceMonitor.swift
+//  Dictate Anywhere
+//
+//  Watches the macOS keyboard input source (Carbon TIS API) and reports
+//  selection changes so mapped transcription profiles can be applied.
+//
+
+import AppKit
+import Carbon
+
+struct InputSourceInfo: Equatable {
+    let id: String
+    let localizedName: String
+    let languageCodes: [String]
+}
+
+@MainActor
+final class InputSourceMonitor {
+    /// Fires (debounced, on the main actor) with the new input source ID.
+    var onSelectedInputSourceChanged: ((String) -> Void)?
+
+    private var observer: NSObjectProtocol?
+    private var debounceTask: Task<Void, Never>?
+
+    func startMonitoring() {
+        guard observer == nil else { return }
+        observer = DistributedNotificationCenter.default().addObserver(
+            forName: Notification.Name(kTISNotifySelectedKeyboardInputSourceChanged as String),
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.scheduleChangeCallback()
+            }
+        }
+    }
+
+    func stopMonitoring() {
+        if let observer {
+            DistributedNotificationCenter.default().removeObserver(observer)
+        }
+        observer = nil
+        debounceTask?.cancel()
+        debounceTask = nil
+    }
+
+    deinit {
+        if let observer {
+            DistributedNotificationCenter.default().removeObserver(observer)
+        }
+    }
+
+    /// Users often cycle through sources with Ctrl+Space; only the source
+    /// they land on matters.
+    private func scheduleChangeCallback() {
+        debounceTask?.cancel()
+        debounceTask = Task { [weak self] in
+            try? await Task.sleep(for: .milliseconds(500))
+            guard !Task.isCancelled else { return }
+            guard let self, let id = self.currentInputSourceID() else { return }
+            self.onSelectedInputSourceChanged?(id)
+        }
+    }
+
+    func currentInputSourceID() -> String? {
+        guard let source = TISCopyCurrentKeyboardInputSource()?.takeRetainedValue() else { return nil }
+        return Self.stringProperty(of: source, key: kTISPropertyInputSourceID)
+    }
+
+    func availableInputSources() -> [InputSourceInfo] {
+        let filter = [
+            kTISPropertyInputSourceCategory as String: kTISCategoryKeyboardInputSource as String,
+        ] as CFDictionary
+        guard let cfList = TISCreateInputSourceList(filter, false)?.takeRetainedValue(),
+              let list = cfList as NSArray as? [TISInputSource] else {
+            return []
+        }
+        return list.compactMap { source in
+            guard Self.boolProperty(of: source, key: kTISPropertyInputSourceIsSelectCapable),
+                  Self.boolProperty(of: source, key: kTISPropertyInputSourceIsEnabled),
+                  let id = Self.stringProperty(of: source, key: kTISPropertyInputSourceID) else {
+                return nil
+            }
+            let name = Self.stringProperty(of: source, key: kTISPropertyLocalizedName) ?? id
+            return InputSourceInfo(id: id, localizedName: name, languageCodes: Self.languageCodes(of: source))
+        }
+    }
+
+    /// Maps an input source's declared BCP-47 codes to a supported language by
+    /// primary subtag ("zh-Hans" -> .chinese). Norwegian keyboards declare
+    /// "nb"; our raw value spells it "no".
+    nonisolated static func deriveLanguage(fromBCP47 codes: [String]) -> SupportedLanguage? {
+        guard let first = codes.first?.lowercased() else { return nil }
+        var primary = first.split(separator: "-").first.map(String.init) ?? first
+        if primary == "nb" { primary = "no" }
+        return SupportedLanguage(rawValue: primary)
+    }
+
+    // MARK: - TIS property helpers
+
+    private nonisolated static func stringProperty(of source: TISInputSource, key: CFString) -> String? {
+        guard let pointer = TISGetInputSourceProperty(source, key) else { return nil }
+        return Unmanaged<CFString>.fromOpaque(pointer).takeUnretainedValue() as String
+    }
+
+    private nonisolated static func boolProperty(of source: TISInputSource, key: CFString) -> Bool {
+        guard let pointer = TISGetInputSourceProperty(source, key) else { return false }
+        return Unmanaged<CFBoolean>.fromOpaque(pointer).takeUnretainedValue() == kCFBooleanTrue
+    }
+
+    private nonisolated static func languageCodes(of source: TISInputSource) -> [String] {
+        guard let pointer = TISGetInputSourceProperty(source, kTISPropertyInputSourceLanguages) else { return [] }
+        return Unmanaged<CFArray>.fromOpaque(pointer).takeUnretainedValue() as NSArray as? [String] ?? []
+    }
+}

--- a/Dictate Anywhere/InputSourceProfileResolver.swift
+++ b/Dictate Anywhere/InputSourceProfileResolver.swift
@@ -30,13 +30,15 @@ enum InputSourceProfileResolver {
         currentFluidAudioLanguage: SupportedLanguage,
         currentAppleSpeechLanguage: SupportedLanguage,
         appleSpeechSupported: Bool,
-        isModelDownloaded: (ParakeetModelChoice) -> Bool
+        isModelDownloaded: (ParakeetModelChoice) -> Bool,
+        isAppleSpeechAssetInstalled: (SupportedLanguage) -> Bool
     ) -> InputSourceProfileResolution {
         guard enabled, let mapping else { return .none }
 
         switch mapping.engine {
         case .appleSpeech:
             guard appleSpeechSupported else { return .inactive }
+            guard isAppleSpeechAssetInstalled(mapping.language) else { return .inactive }
             guard currentEngine == .appleSpeech else { return .fullApply }
             return mapping.language == currentAppleSpeechLanguage
                 ? .noChange

--- a/Dictate Anywhere/InputSourceProfileResolver.swift
+++ b/Dictate Anywhere/InputSourceProfileResolver.swift
@@ -1,0 +1,54 @@
+//
+//  InputSourceProfileResolver.swift
+//  Dictate Anywhere
+//
+//  Pure decision logic for input-source auto-switching: given a mapping and
+//  the current engine state, decides what (if anything) must change.
+//
+
+import Foundation
+
+enum InputSourceProfileResolution: Equatable {
+    /// Feature disabled, source unmapped, or mapping malformed.
+    case none
+    /// Profile already active.
+    case noChange
+    /// Same engine and model; only the language differs.
+    case languageOnly(SupportedLanguage)
+    /// Engine and/or model must change (expensive path).
+    case fullApply
+    /// Mapping cannot be applied (model not downloaded / engine unsupported).
+    case inactive
+}
+
+enum InputSourceProfileResolver {
+    static func resolve(
+        mapping: InputSourceMapping?,
+        enabled: Bool,
+        currentEngine: TranscriptionEngineChoice,
+        currentParakeetModel: ParakeetModelChoice,
+        currentFluidAudioLanguage: SupportedLanguage,
+        currentAppleSpeechLanguage: SupportedLanguage,
+        appleSpeechSupported: Bool,
+        isModelDownloaded: (ParakeetModelChoice) -> Bool
+    ) -> InputSourceProfileResolution {
+        guard enabled, let mapping else { return .none }
+
+        switch mapping.engine {
+        case .appleSpeech:
+            guard appleSpeechSupported else { return .inactive }
+            guard currentEngine == .appleSpeech else { return .fullApply }
+            return mapping.language == currentAppleSpeechLanguage
+                ? .noChange
+                : .languageOnly(mapping.language)
+
+        case .parakeet:
+            guard let model = mapping.parakeetModel else { return .none }
+            guard isModelDownloaded(model) else { return .inactive }
+            guard currentEngine == .parakeet, model == currentParakeetModel else { return .fullApply }
+            return mapping.language == currentFluidAudioLanguage
+                ? .noChange
+                : .languageOnly(mapping.language)
+        }
+    }
+}

--- a/Dictate Anywhere/InputSourceProfileResolver.swift
+++ b/Dictate Anywhere/InputSourceProfileResolver.swift
@@ -72,7 +72,7 @@ enum InputSourceMappingAvailability {
                 return "Apple Speech isn't available on this Mac."
             }
             guard installedAppleSpeechLanguages.contains(mapping.language) else {
-                return "\(mapping.language.displayName) isn't installed for Apple Speech. Select it once under Transcription language to download it."
+                return "\(mapping.language.displayName) isn't installed for Apple Speech. Choose Apple Speech under Speech Model, then pick the language under Transcription language to download it."
             }
             return nil
         case .parakeet:

--- a/Dictate Anywhere/InputSourceProfileResolver.swift
+++ b/Dictate Anywhere/InputSourceProfileResolver.swift
@@ -54,3 +54,36 @@ enum InputSourceProfileResolver {
         }
     }
 }
+
+/// Why a mapping cannot currently apply on this machine, phrased for the
+/// settings UI — or nil when the mapping is active. Pure so the matrix is
+/// unit-testable; the UI injects live caches/closures.
+enum InputSourceMappingAvailability {
+    static func inactiveReason(
+        for mapping: InputSourceMapping,
+        appleSpeechSupported: Bool,
+        installedAppleSpeechLanguages: [SupportedLanguage],
+        runnableModels: [ParakeetModelChoice],
+        isModelOnDisk: (ParakeetModelChoice) -> Bool
+    ) -> String? {
+        switch mapping.engine {
+        case .appleSpeech:
+            guard appleSpeechSupported else {
+                return "Apple Speech isn't available on this Mac."
+            }
+            guard installedAppleSpeechLanguages.contains(mapping.language) else {
+                return "\(mapping.language.displayName) isn't installed for Apple Speech. Select it once under Transcription language to download it."
+            }
+            return nil
+        case .parakeet:
+            guard let model = mapping.parakeetModel else { return nil }
+            guard runnableModels.contains(model) else {
+                return "\(model.displayName) isn't available on this Mac."
+            }
+            guard isModelOnDisk(model) else {
+                return "\(model.displayName) isn't downloaded. Get it in Speech Model settings — auto-switching never downloads models."
+            }
+            return nil
+        }
+    }
+}

--- a/Dictate Anywhere/InputSourceSettingsSection.swift
+++ b/Dictate Anywhere/InputSourceSettingsSection.swift
@@ -41,7 +41,7 @@ struct InputSourceSettingsSection: View {
             .onChange(of: settings.inputSourceAutoSwitchEnabled) { _, enabled in
                 guard enabled,
                       let inputSourceID = appState.inputSourceMonitor.currentInputSourceID() else { return }
-                Task { await appState.applyInputSourceProfile(for: inputSourceID) }
+                appState.enqueueInputSourceProfileApply(for: inputSourceID)
             }
 
             if settings.inputSourceAutoSwitchEnabled {

--- a/Dictate Anywhere/InputSourceSettingsSection.swift
+++ b/Dictate Anywhere/InputSourceSettingsSection.swift
@@ -1,0 +1,239 @@
+//
+//  InputSourceSettingsSection.swift
+//  Dictate Anywhere
+//
+//  "Input Source Switching" section of General settings: opt-in toggle plus
+//  per-input-source mapping rows. Language/model options are always derived
+//  from ParakeetModelChoice / Apple Speech capability APIs — no local tables.
+//
+
+import SwiftUI
+
+struct InputSourceSettingsSection: View {
+    @Environment(AppState.self) private var appState
+
+    var body: some View {
+        @Bindable var settings = appState.settings
+        let availableSources = appState.inputSourceMonitor.availableInputSources()
+
+        VStack(alignment: .leading, spacing: DS.Spacing.section) {
+            DSSection(overline: "Input Source Switching") {
+                DSStackedRow(
+                    label: "Match speech model to keyboard input source",
+                    caption: "When you change keyboard input sources, apply the mapped engine, model, and language automatically.",
+                    isOn: $settings.inputSourceAutoSwitchEnabled
+                )
+                if settings.inputSourceAutoSwitchEnabled {
+                    ForEach(settings.inputSourceMappings) { mapping in
+                        DSDivider()
+                        InputSourceMappingRow(
+                            mapping: mapping,
+                            availableSources: availableSources,
+                            takenSourceIDs: Set(
+                                settings.inputSourceMappings
+                                    .filter { $0.id != mapping.id }
+                                    .map(\.inputSourceID)
+                            )
+                        )
+                    }
+                }
+            }
+            .onChange(of: settings.inputSourceAutoSwitchEnabled) { _, enabled in
+                guard enabled,
+                      let inputSourceID = appState.inputSourceMonitor.currentInputSourceID() else { return }
+                Task { await appState.applyInputSourceProfile(for: inputSourceID) }
+            }
+
+            if settings.inputSourceAutoSwitchEnabled {
+                if canAddMapping(availableSources: availableSources) {
+                    DSAddButton(title: "Add mapping") {
+                        addMapping(availableSources: availableSources)
+                    }
+                }
+                if !inactiveMappingNames.isEmpty {
+                    DSHint(
+                        text: "Inactive until downloaded in Speech Model settings: \(inactiveMappingNames.joined(separator: ", ")). Auto-switching never downloads models.",
+                        icon: "exclamationmark.triangle"
+                    )
+                }
+            }
+        }
+    }
+
+    private var inactiveMappingNames: [String] {
+        appState.settings.inputSourceMappings.compactMap { mapping in
+            switch mapping.engine {
+            case .appleSpeech:
+                return AppleSpeechEngine.isSupported ? nil : "Apple Speech"
+            case .parakeet:
+                guard let model = mapping.parakeetModel else { return nil }
+                return appState.parakeetEngine.checkModelOnDisk(for: model) ? nil : model.displayName
+            }
+        }
+    }
+
+    private func canAddMapping(availableSources: [InputSourceInfo]) -> Bool {
+        let taken = Set(appState.settings.inputSourceMappings.map(\.inputSourceID))
+        return availableSources.contains { !taken.contains($0.id) }
+    }
+
+    private func addMapping(availableSources: [InputSourceInfo]) {
+        let settings = appState.settings
+        let taken = Set(settings.inputSourceMappings.map(\.inputSourceID))
+        guard let source = availableSources.first(where: { !taken.contains($0.id) }) else { return }
+        settings.addInputSourceMapping(
+            inputSourceID: source.id,
+            displayName: source.localizedName,
+            derivedLanguage: InputSourceMonitor.deriveLanguage(fromBCP47: source.languageCodes),
+            isModelDownloaded: { appState.parakeetEngine.checkModelOnDisk(for: $0) }
+        )
+    }
+}
+
+// MARK: - Mapping Row
+
+private struct InputSourceMappingRow: View {
+    @Environment(AppState.self) private var appState
+    let mapping: InputSourceMapping
+    let availableSources: [InputSourceInfo]
+    let takenSourceIDs: Set<String>
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            DSInfoRow(label: "Input source") {
+                HStack(spacing: 10) {
+                    DSDropdown(
+                        selection: sourceBinding,
+                        options: sourceOptions,
+                        title: { sourceName(for: $0) }
+                    )
+                    DSIconButton(
+                        systemImage: "trash",
+                        accessibilityLabel: "Delete mapping"
+                    ) {
+                        appState.settings.removeInputSourceMapping(id: mapping.id)
+                    }
+                }
+            }
+            DSInfoRow(label: "Engine") {
+                DSDropdown(
+                    selection: engineBinding,
+                    options: engineOptions,
+                    title: \.displayName
+                )
+            }
+            if mapping.engine == .parakeet {
+                DSInfoRow(label: "Model") {
+                    DSDropdown(
+                        selection: modelBinding,
+                        options: Array(ParakeetModelChoice.allCases),
+                        title: { modelTitle(for: $0) }
+                    )
+                }
+            }
+            languageRow
+        }
+    }
+
+    @ViewBuilder
+    private var languageRow: some View {
+        DSInfoRow(label: "Language") {
+            if mapping.engine == .appleSpeech {
+                DSDropdown(
+                    selection: languageBinding,
+                    options: appState.appleSpeechSupportedLanguages.isEmpty
+                        ? [mapping.language]
+                        : appState.appleSpeechSupportedLanguages,
+                    title: \.displayWithFlag
+                )
+            } else if let selectable = mapping.parakeetModel?.selectableLanguages {
+                DSDropdown(
+                    selection: languageBinding,
+                    options: selectable,
+                    title: \.displayWithFlag
+                )
+            } else {
+                Text(mapping.parakeetModel?.fixedLanguageLabel ?? "")
+                    .font(DS.Fonts.ui(13.5))
+                    .foregroundStyle(DS.Colors.textSecondary)
+            }
+        }
+    }
+
+    // MARK: Options & titles
+
+    private var sourceOptions: [String] {
+        var ids = availableSources.map(\.id).filter { !takenSourceIDs.contains($0) }
+        if !ids.contains(mapping.inputSourceID) {
+            ids.insert(mapping.inputSourceID, at: 0)
+        }
+        return ids
+    }
+
+    private func sourceName(for id: String) -> String {
+        if let source = availableSources.first(where: { $0.id == id }) {
+            return source.localizedName
+        }
+        // Source no longer enabled in macOS; show the cached name.
+        return "\(mapping.inputSourceDisplayName) (not enabled)"
+    }
+
+    private var engineOptions: [TranscriptionEngineChoice] {
+        AppleSpeechEngine.isSupported ? Array(TranscriptionEngineChoice.allCases) : [.parakeet]
+    }
+
+    private func modelTitle(for model: ParakeetModelChoice) -> String {
+        appState.parakeetEngine.checkModelOnDisk(for: model)
+            ? model.displayName
+            : "\(model.displayName) (not downloaded)"
+    }
+
+    // MARK: Bindings (route every edit through updateInputSourceMapping)
+
+    private var sourceBinding: Binding<String> {
+        Binding(
+            get: { mapping.inputSourceID },
+            set: { newID in
+                var updated = mapping
+                updated.inputSourceID = newID
+                if let source = availableSources.first(where: { $0.id == newID }) {
+                    updated.inputSourceDisplayName = source.localizedName
+                }
+                appState.settings.updateInputSourceMapping(updated)
+            }
+        )
+    }
+
+    private var engineBinding: Binding<TranscriptionEngineChoice> {
+        Binding(
+            get: { mapping.engine },
+            set: { newEngine in
+                var updated = mapping
+                updated.engine = newEngine
+                appState.settings.updateInputSourceMapping(updated)
+            }
+        )
+    }
+
+    private var modelBinding: Binding<ParakeetModelChoice> {
+        Binding(
+            get: { mapping.parakeetModel ?? appState.settings.parakeetModelChoice },
+            set: { newModel in
+                var updated = mapping
+                updated.parakeetModel = newModel
+                appState.settings.updateInputSourceMapping(updated)
+            }
+        )
+    }
+
+    private var languageBinding: Binding<SupportedLanguage> {
+        Binding(
+            get: { mapping.language },
+            set: { newLanguage in
+                var updated = mapping
+                updated.language = newLanguage
+                appState.settings.updateInputSourceMapping(updated)
+            }
+        )
+    }
+}

--- a/Dictate Anywhere/InputSourceSettingsSection.swift
+++ b/Dictate Anywhere/InputSourceSettingsSection.swift
@@ -64,12 +64,15 @@ struct InputSourceSettingsSection: View {
         let settings = appState.settings
         let taken = Set(settings.inputSourceMappings.map(\.inputSourceID))
         guard let source = availableSources.first(where: { !taken.contains($0.id) }) else { return }
-        settings.addInputSourceMapping(
+        let mapping = settings.addInputSourceMapping(
             inputSourceID: source.id,
             displayName: source.localizedName,
             derivedLanguage: InputSourceMonitor.deriveLanguage(fromBCP47: source.languageCodes),
             isModelDownloaded: { appState.parakeetEngine.checkModelOnDisk(for: $0) && $0.isAvailableOnThisMac }
         )
+        if let mapping, mapping.inputSourceID == appState.inputSourceMonitor.currentInputSourceID() {
+            appState.enqueueInputSourceProfileApply(for: mapping.inputSourceID)
+        }
     }
 }
 
@@ -189,7 +192,7 @@ private struct InputSourceMappingRow: View {
             : "\(model.displayName) (not downloaded)"
     }
 
-    // MARK: Bindings (route every edit through updateInputSourceMapping)
+    // MARK: Bindings (route every edit through commit)
 
     private var sourceBinding: Binding<String> {
         Binding(
@@ -200,7 +203,7 @@ private struct InputSourceMappingRow: View {
                 if let source = availableSources.first(where: { $0.id == newID }) {
                     updated.inputSourceDisplayName = source.localizedName
                 }
-                appState.settings.updateInputSourceMapping(updated)
+                commit(updated)
             }
         )
     }
@@ -211,7 +214,7 @@ private struct InputSourceMappingRow: View {
             set: { newEngine in
                 var updated = mapping
                 updated.engine = newEngine
-                appState.settings.updateInputSourceMapping(updated)
+                commit(updated)
             }
         )
     }
@@ -222,7 +225,7 @@ private struct InputSourceMappingRow: View {
             set: { newModel in
                 var updated = mapping
                 updated.parakeetModel = newModel
-                appState.settings.updateInputSourceMapping(updated)
+                commit(updated)
             }
         )
     }
@@ -233,8 +236,18 @@ private struct InputSourceMappingRow: View {
             set: { newLanguage in
                 var updated = mapping
                 updated.language = newLanguage
-                appState.settings.updateInputSourceMapping(updated)
+                commit(updated)
             }
         )
+    }
+
+    /// Persists an edit and, when the row governs the input source that is
+    /// active right now, immediately enqueues the profile apply so the model
+    /// pre-warms instead of waiting for the next source change or recording.
+    private func commit(_ updated: InputSourceMapping) {
+        appState.settings.updateInputSourceMapping(updated)
+        if updated.inputSourceID == appState.inputSourceMonitor.currentInputSourceID() {
+            appState.enqueueInputSourceProfileApply(for: updated.inputSourceID)
+        }
     }
 }

--- a/Dictate Anywhere/InputSourceSettingsSection.swift
+++ b/Dictate Anywhere/InputSourceSettingsSection.swift
@@ -85,7 +85,7 @@ struct InputSourceSettingsSection: View {
             inputSourceID: source.id,
             displayName: source.localizedName,
             derivedLanguage: InputSourceMonitor.deriveLanguage(fromBCP47: source.languageCodes),
-            isModelDownloaded: { appState.parakeetEngine.checkModelOnDisk(for: $0) }
+            isModelDownloaded: { appState.parakeetEngine.checkModelOnDisk(for: $0) && $0.isAvailableOnThisMac }
         )
     }
 }
@@ -126,7 +126,7 @@ private struct InputSourceMappingRow: View {
                 DSInfoRow(label: "Model") {
                     DSDropdown(
                         selection: modelBinding,
-                        options: Array(ParakeetModelChoice.allCases),
+                        options: ParakeetModelChoice.availableCases,
                         title: { modelTitle(for: $0) }
                     )
                 }
@@ -183,7 +183,10 @@ private struct InputSourceMappingRow: View {
     }
 
     private func modelTitle(for model: ParakeetModelChoice) -> String {
-        appState.parakeetEngine.checkModelOnDisk(for: model)
+        guard model.isAvailableOnThisMac else {
+            return "\(model.displayName) (not available on this Mac)"
+        }
+        return appState.parakeetEngine.checkModelOnDisk(for: model)
             ? model.displayName
             : "\(model.displayName) (not downloaded)"
     }

--- a/Dictate Anywhere/InputSourceSettingsSection.swift
+++ b/Dictate Anywhere/InputSourceSettingsSection.swift
@@ -50,26 +50,9 @@ struct InputSourceSettingsSection: View {
                         addMapping(availableSources: availableSources)
                     }
                 }
-                if !inactiveMappingNames.isEmpty {
-                    DSHint(
-                        text: "Inactive until downloaded in Speech Model settings: \(inactiveMappingNames.joined(separator: ", ")). Auto-switching never downloads models.",
-                        icon: "exclamationmark.triangle"
-                    )
-                }
             }
         }
-    }
-
-    private var inactiveMappingNames: [String] {
-        appState.settings.inputSourceMappings.compactMap { mapping in
-            switch mapping.engine {
-            case .appleSpeech:
-                return AppleSpeechEngine.isSupported ? nil : "Apple Speech"
-            case .parakeet:
-                guard let model = mapping.parakeetModel else { return nil }
-                return appState.parakeetEngine.checkModelOnDisk(for: model) ? nil : model.displayName
-            }
-        }
+        .task { await appState.refreshAppleSpeechAssetState() }
     }
 
     private func canAddMapping(availableSources: [InputSourceInfo]) -> Bool {
@@ -132,7 +115,22 @@ private struct InputSourceMappingRow: View {
                 }
             }
             languageRow
+            if let reason = inactiveReason {
+                DSHint(text: reason, icon: "exclamationmark.triangle")
+                    .padding(.horizontal, DS.Spacing.rowHorizontal)
+                    .padding(.bottom, 10)
+            }
         }
+    }
+
+    private var inactiveReason: String? {
+        InputSourceMappingAvailability.inactiveReason(
+            for: mapping,
+            appleSpeechSupported: AppleSpeechEngine.isSupported,
+            installedAppleSpeechLanguages: appState.appleSpeechInstalledLanguages,
+            runnableModels: ParakeetModelChoice.availableCases,
+            isModelOnDisk: { appState.parakeetEngine.checkModelOnDisk(for: $0) }
+        )
     }
 
     @ViewBuilder

--- a/Dictate Anywhere/OverlayContent.swift
+++ b/Dictate Anywhere/OverlayContent.swift
@@ -26,6 +26,7 @@ enum OverlayState: Equatable {
     case processing
     case success
     case copiedOnly
+    case preparingModel(name: String)
 }
 
 /// Observable model bridging OverlayWindow → SwiftUI
@@ -72,6 +73,7 @@ struct OverlayContent: View {
         case .processing: "processing"
         case .success: "success"
         case .copiedOnly: "copiedOnly"
+        case .preparingModel: "preparingModel"
         }
     }
 
@@ -100,6 +102,8 @@ struct OverlayContent: View {
             return statusCircleDiameter
         case .copiedOnly:
             return OverlayMetrics.size(130)
+        case .preparingModel:
+            return OverlayMetrics.size(240)
         }
     }
 
@@ -110,6 +114,8 @@ struct OverlayContent: View {
         case .processing, .success:
             return statusCircleDiameter
         case .copiedOnly:
+            return OverlayMetrics.size(44)
+        case .preparingModel:
             return OverlayMetrics.size(44)
         }
     }
@@ -167,6 +173,16 @@ struct OverlayContent: View {
                     .font(.system(size: OverlayMetrics.type(12), weight: .medium))
                     .foregroundStyle(overlayTextColor.opacity(0.9))
             }
+
+        case .preparingModel(let name):
+            HStack(spacing: OverlayMetrics.size(10)) {
+                ProcessingStatusView(tint: overlayTextColor)
+                Text("Loading \(name)…")
+                    .font(.system(size: OverlayMetrics.type(12), weight: .medium))
+                    .foregroundStyle(overlayTextColor.opacity(0.9))
+                    .lineLimit(1)
+            }
+            .padding(.horizontal, OverlayMetrics.size(14))
         }
     }
 

--- a/Dictate Anywhere/Settings.swift
+++ b/Dictate Anywhere/Settings.swift
@@ -78,7 +78,7 @@ enum AppAppearanceMode: String, CaseIterable {
 
 // MARK: - Transcription Engine Choice
 
-enum TranscriptionEngineChoice: String, CaseIterable {
+enum TranscriptionEngineChoice: String, CaseIterable, Codable {
     case parakeet = "parakeet"
     case appleSpeech = "appleSpeech"
 
@@ -99,7 +99,7 @@ enum TranscriptionEngineChoice: String, CaseIterable {
     }
 }
 
-enum ParakeetModelChoice: String, CaseIterable {
+enum ParakeetModelChoice: String, CaseIterable, Codable {
     case multilingual = "multilingual"
     case englishOnly = "englishOnly"
     case compactEnglish = "compactEnglish"
@@ -528,6 +528,31 @@ struct HotkeyBinding: Codable, Identifiable, Equatable {
     )
 }
 
+/// One user-configured input-source → transcription-profile mapping.
+/// Language/model capability is never stored here — it is always resolved
+/// through `ParakeetModelChoice` / Apple Speech at read time.
+struct InputSourceMapping: Codable, Identifiable, Equatable {
+    var id: UUID
+    var inputSourceID: String
+    /// Cached for display when the source is no longer enabled in macOS.
+    var inputSourceDisplayName: String
+    var engine: TranscriptionEngineChoice
+    /// Present iff `engine == .parakeet`.
+    var parakeetModel: ParakeetModelChoice?
+    var language: SupportedLanguage
+}
+
+/// Decode-tolerant shape: enum raw values may vanish across app versions,
+/// and a strict `[InputSourceMapping]` decode would throw away every entry.
+private struct RawInputSourceMapping: Decodable {
+    let id: UUID
+    let inputSourceID: String
+    let inputSourceDisplayName: String
+    let engine: String
+    let parakeetModel: String?
+    let language: String
+}
+
 struct TranscriptHistoryEntry: Identifiable, Codable, Equatable {
     let id: UUID
     let text: String
@@ -646,6 +671,8 @@ final class Settings {
         static let openAICompatibleBaseURL = "openAICompatibleBaseURL"
         static let openAICompatibleModel = "openAICompatibleModel"
         static let openAICompatiblePostProcessingPrompt = "openAICompatiblePostProcessingPrompt"
+        static let inputSourceMappings = "inputSourceMappings"
+        static let inputSourceAutoSwitchEnabled = "inputSourceAutoSwitchEnabled"
     }
 
     // MARK: - Hotkey Settings
@@ -723,6 +750,45 @@ final class Settings {
     var appleSpeechLanguage: SupportedLanguage {
         didSet {
             UserDefaults.standard.set(appleSpeechLanguage.rawValue, forKey: Keys.appleSpeechLanguage)
+        }
+    }
+
+    // MARK: - Input Source Auto-Switch
+
+    var inputSourceMappings: [InputSourceMapping] {
+        didSet {
+            guard let data = try? JSONEncoder().encode(inputSourceMappings) else { return }
+            UserDefaults.standard.set(data, forKey: Keys.inputSourceMappings)
+        }
+    }
+
+    var inputSourceAutoSwitchEnabled: Bool {
+        didSet {
+            UserDefaults.standard.set(inputSourceAutoSwitchEnabled, forKey: Keys.inputSourceAutoSwitchEnabled)
+        }
+    }
+
+    /// Decodes mappings, dropping entries whose enum raw values no longer
+    /// exist and parakeet entries missing a model.
+    nonisolated static func sanitizedMappings(from data: Data) -> [InputSourceMapping] {
+        guard let raw = try? JSONDecoder().decode([RawInputSourceMapping].self, from: data) else { return [] }
+        return raw.compactMap { entry in
+            guard let engine = TranscriptionEngineChoice(rawValue: entry.engine),
+                  let language = SupportedLanguage(rawValue: entry.language) else { return nil }
+            var model: ParakeetModelChoice?
+            if let rawModel = entry.parakeetModel {
+                guard let parsed = ParakeetModelChoice(rawValue: rawModel) else { return nil }
+                model = parsed
+            }
+            if engine == .parakeet, model == nil { return nil }
+            return InputSourceMapping(
+                id: entry.id,
+                inputSourceID: entry.inputSourceID,
+                inputSourceDisplayName: entry.inputSourceDisplayName,
+                engine: engine,
+                parakeetModel: model,
+                language: language
+            )
         }
     }
 
@@ -1030,6 +1096,14 @@ final class Settings {
         selectedLanguage = SupportedLanguage(rawValue: langCode) ?? .english
         let appleLangCode = defaults.string(forKey: Keys.appleSpeechLanguage) ?? "en"
         appleSpeechLanguage = SupportedLanguage(rawValue: appleLangCode) ?? .english
+
+        // Input source auto-switching
+        if let mappingData = defaults.data(forKey: Keys.inputSourceMappings) {
+            inputSourceMappings = Self.sanitizedMappings(from: mappingData)
+        } else {
+            inputSourceMappings = []
+        }
+        inputSourceAutoSwitchEnabled = defaults.object(forKey: Keys.inputSourceAutoSwitchEnabled) as? Bool ?? false
 
         // Filler words
         isFillerWordRemovalEnabled = defaults.object(forKey: Keys.isFillerWordRemovalEnabled) as? Bool ?? false

--- a/Dictate Anywhere/Settings.swift
+++ b/Dictate Anywhere/Settings.swift
@@ -673,6 +673,7 @@ final class Settings {
         static let openAICompatiblePostProcessingPrompt = "openAICompatiblePostProcessingPrompt"
         static let inputSourceMappings = "inputSourceMappings"
         static let inputSourceAutoSwitchEnabled = "inputSourceAutoSwitchEnabled"
+        static let pendingVocabularyModeRestore = "pendingVocabularyModeRestore"
     }
 
     // MARK: - Hotkey Settings
@@ -765,6 +766,17 @@ final class Settings {
     var inputSourceAutoSwitchEnabled: Bool {
         didSet {
             UserDefaults.standard.set(inputSourceAutoSwitchEnabled, forKey: Keys.inputSourceAutoSwitchEnabled)
+        }
+    }
+
+    /// Set when an auto-switch coerced `.fluidAudioVocabulary` away because
+    /// the destination model didn't support it. Consulted the next time an
+    /// auto-switch lands so the mode can be restored once a vocab-capable
+    /// model is active again, without clobbering a mode the user picked
+    /// manually in the meantime.
+    var pendingVocabularyModeRestore: Bool {
+        didSet {
+            UserDefaults.standard.set(pendingVocabularyModeRestore, forKey: Keys.pendingVocabularyModeRestore)
         }
     }
 
@@ -1111,6 +1123,7 @@ final class Settings {
             inputSourceMappings = []
         }
         inputSourceAutoSwitchEnabled = defaults.object(forKey: Keys.inputSourceAutoSwitchEnabled) as? Bool ?? false
+        pendingVocabularyModeRestore = defaults.object(forKey: Keys.pendingVocabularyModeRestore) as? Bool ?? false
 
         // Filler words
         isFillerWordRemovalEnabled = defaults.object(forKey: Keys.isFillerWordRemovalEnabled) as? Bool ?? false
@@ -1352,6 +1365,32 @@ final class Settings {
 
     func mapping(forInputSourceID id: String) -> InputSourceMapping? {
         inputSourceMappings.first { $0.inputSourceID == id }
+    }
+
+    /// Call right after an auto-switch may have driven the `parakeetModelChoice`
+    /// or `engineChoice` didSet coercion that strips `.fluidAudioVocabulary`.
+    /// `hadVocabularyMode` is the mode captured *before* that write. Sets the
+    /// pending-restore flag only when the coercion actually fired.
+    func noteAutoSwitchModelChange(hadVocabularyMode: Bool) {
+        guard hadVocabularyMode, transcriptPostProcessingMode != .fluidAudioVocabulary else { return }
+        pendingVocabularyModeRestore = true
+    }
+
+    /// Call after every auto-switch resolution (including no-ops) so a
+    /// pending restore lands as soon as a vocab-capable Parakeet model is
+    /// active again, without overriding a mode the user picked manually in
+    /// the meantime.
+    func restoreVocabularyModeAfterAutoSwitchIfPending() {
+        guard pendingVocabularyModeRestore else { return }
+
+        if transcriptPostProcessingMode == .fluidAudioVocabulary {
+            pendingVocabularyModeRestore = false
+        } else if transcriptPostProcessingMode != .none {
+            pendingVocabularyModeRestore = false
+        } else if engineChoice == .parakeet, parakeetModelChoice.supportsFluidAudioVocabulary {
+            transcriptPostProcessingMode = .fluidAudioVocabulary
+            pendingVocabularyModeRestore = false
+        }
     }
 
     func addTranscriptHistoryEntry(_ text: String) {

--- a/Dictate Anywhere/Settings.swift
+++ b/Dictate Anywhere/Settings.swift
@@ -1274,6 +1274,79 @@ final class Settings {
         hotkeyBindings.removeAll { $0.id == id }
     }
 
+    // MARK: - Input Source Mapping Helpers
+
+    /// Adds a mapping for a not-yet-mapped input source, deriving sensible
+    /// defaults. `isModelDownloaded` is injected because on-disk state lives
+    /// in ParakeetEngine; auto-picking a model must never imply a download.
+    @discardableResult
+    func addInputSourceMapping(
+        inputSourceID: String,
+        displayName: String,
+        derivedLanguage: SupportedLanguage?,
+        isModelDownloaded: (ParakeetModelChoice) -> Bool
+    ) -> InputSourceMapping? {
+        guard !inputSourceMappings.contains(where: { $0.inputSourceID == inputSourceID }) else { return nil }
+        let engine = engineChoice
+        var language = derivedLanguage ?? (engine == .appleSpeech ? appleSpeechLanguage : selectedLanguage)
+        var model: ParakeetModelChoice?
+        if engine == .parakeet {
+            if let derived = derivedLanguage,
+               !parakeetModelChoice.supportsLanguage(derived),
+               let downloaded = ParakeetModelChoice.allCases.first(where: {
+                   $0.supportsLanguage(derived) && isModelDownloaded($0)
+               }) {
+                model = downloaded
+            } else {
+                model = parakeetModelChoice
+            }
+            if let chosen = model, !chosen.supportsLanguage(language) {
+                language = .english
+            }
+        }
+        let mapping = InputSourceMapping(
+            id: UUID(),
+            inputSourceID: inputSourceID,
+            inputSourceDisplayName: displayName,
+            engine: engine,
+            parakeetModel: model,
+            language: language
+        )
+        inputSourceMappings.append(mapping)
+        return mapping
+    }
+
+    /// Replaces a mapping by ID, normalizing model/language so every stored
+    /// mapping satisfies the capability rules. Apple Speech language
+    /// availability is validated at apply time (the authority is
+    /// AppleSpeechEngine, which Settings cannot query synchronously).
+    func updateInputSourceMapping(_ mapping: InputSourceMapping) {
+        guard let index = inputSourceMappings.firstIndex(where: { $0.id == mapping.id }) else { return }
+        guard !inputSourceMappings.contains(where: {
+            $0.id != mapping.id && $0.inputSourceID == mapping.inputSourceID
+        }) else { return }
+        var updated = mapping
+        switch updated.engine {
+        case .appleSpeech:
+            updated.parakeetModel = nil
+        case .parakeet:
+            let model = updated.parakeetModel ?? parakeetModelChoice
+            updated.parakeetModel = model
+            if !model.supportsLanguage(updated.language) {
+                updated.language = .english
+            }
+        }
+        inputSourceMappings[index] = updated
+    }
+
+    func removeInputSourceMapping(id: UUID) {
+        inputSourceMappings.removeAll { $0.id == id }
+    }
+
+    func mapping(forInputSourceID id: String) -> InputSourceMapping? {
+        inputSourceMappings.first { $0.inputSourceID == id }
+    }
+
     func addTranscriptHistoryEntry(_ text: String) {
         let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedText.isEmpty else { return }

--- a/Dictate Anywhere/Settings.swift
+++ b/Dictate Anywhere/Settings.swift
@@ -769,18 +769,25 @@ final class Settings {
     }
 
     /// Decodes mappings, dropping entries whose enum raw values no longer
-    /// exist and parakeet entries missing a model.
+    /// exist and parakeet entries missing a model. Also re-coerces the
+    /// language against the model's capability, since a model's supported
+    /// language set can change across app versions after a mapping was
+    /// stored (same rule as the `parakeetModelChoice` didSet and the
+    /// mutation helpers below).
     nonisolated static func sanitizedMappings(from data: Data) -> [InputSourceMapping] {
         guard let raw = try? JSONDecoder().decode([RawInputSourceMapping].self, from: data) else { return [] }
         return raw.compactMap { entry in
             guard let engine = TranscriptionEngineChoice(rawValue: entry.engine),
-                  let language = SupportedLanguage(rawValue: entry.language) else { return nil }
+                  var language = SupportedLanguage(rawValue: entry.language) else { return nil }
             var model: ParakeetModelChoice?
             if let rawModel = entry.parakeetModel {
                 guard let parsed = ParakeetModelChoice(rawValue: rawModel) else { return nil }
                 model = parsed
             }
             if engine == .parakeet, model == nil { return nil }
+            if engine == .parakeet, model?.supportsLanguage(language) == false {
+                language = .english
+            }
             return InputSourceMapping(
                 id: entry.id,
                 inputSourceID: entry.inputSourceID,

--- a/Dictate Anywhere/SettingsView.swift
+++ b/Dictate Anywhere/SettingsView.swift
@@ -77,6 +77,8 @@ struct SettingsView: View {
                 }
             }
 
+            InputSourceSettingsSection()
+
             DSSection(overline: "Audio") {
                 DSInfoRow(label: "Microphone") {
                     DSDropdown(

--- a/Dictate AnywhereTests/InputSourceMappingAvailabilityTests.swift
+++ b/Dictate AnywhereTests/InputSourceMappingAvailabilityTests.swift
@@ -1,0 +1,84 @@
+import XCTest
+@testable import Dictate_Anywhere_Dev
+
+/// Pure availability-reason tests — no Settings.shared mutation, no snapshot needed.
+final class InputSourceMappingAvailabilityTests: XCTestCase {
+    private func mapping(
+        engine: TranscriptionEngineChoice = .parakeet,
+        model: ParakeetModelChoice? = .senseVoice,
+        language: SupportedLanguage = .chinese
+    ) -> InputSourceMapping {
+        InputSourceMapping(
+            id: UUID(), inputSourceID: "src", inputSourceDisplayName: "Src",
+            engine: engine, parakeetModel: model, language: language
+        )
+    }
+
+    private func reason(
+        for mapping: InputSourceMapping,
+        appleSpeechSupported: Bool = true,
+        installedAppleSpeechLanguages: [SupportedLanguage] = [],
+        runnableModels: [ParakeetModelChoice] = ParakeetModelChoice.availableCases(hasNeuralEngine: true),
+        isModelOnDisk: @escaping (ParakeetModelChoice) -> Bool = { _ in true }
+    ) -> String? {
+        InputSourceMappingAvailability.inactiveReason(
+            for: mapping,
+            appleSpeechSupported: appleSpeechSupported,
+            installedAppleSpeechLanguages: installedAppleSpeechLanguages,
+            runnableModels: runnableModels,
+            isModelOnDisk: isModelOnDisk
+        )
+    }
+
+    func testAppleSpeechUnsupportedReturnsUnavailableReason() {
+        let result = reason(
+            for: mapping(engine: .appleSpeech, model: nil, language: .german),
+            appleSpeechSupported: false
+        )
+        XCTAssertEqual(result, "Apple Speech isn't available on this Mac.")
+    }
+
+    func testAppleSpeechSupportedButLanguageNotInstalledReturnsInstallPrompt() {
+        let result = reason(
+            for: mapping(engine: .appleSpeech, model: nil, language: .german),
+            appleSpeechSupported: true,
+            installedAppleSpeechLanguages: [.english]
+        )
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result!.contains("isn't installed for Apple Speech"))
+    }
+
+    func testAppleSpeechInstalledReturnsNil() {
+        let result = reason(
+            for: mapping(engine: .appleSpeech, model: nil, language: .german),
+            appleSpeechSupported: true,
+            installedAppleSpeechLanguages: [.german]
+        )
+        XCTAssertNil(result)
+    }
+
+    func testParakeetModelNotRunnableOnThisHardwareReturnsUnavailableReason() {
+        let result = reason(
+            for: mapping(model: .nemotronMultilingual),
+            runnableModels: ParakeetModelChoice.availableCases(hasNeuralEngine: false)
+        )
+        XCTAssertEqual(result, "\(ParakeetModelChoice.nemotronMultilingual.displayName) isn't available on this Mac.")
+    }
+
+    func testParakeetRunnableButNotOnDiskReturnsDownloadPrompt() {
+        let result = reason(
+            for: mapping(model: .senseVoice),
+            isModelOnDisk: { _ in false }
+        )
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result!.contains("isn't downloaded"))
+    }
+
+    func testParakeetRunnableAndOnDiskReturnsNil() {
+        let result = reason(
+            for: mapping(model: .senseVoice),
+            isModelOnDisk: { _ in true }
+        )
+        XCTAssertNil(result)
+    }
+}

--- a/Dictate AnywhereTests/InputSourceMappingTests.swift
+++ b/Dictate AnywhereTests/InputSourceMappingTests.swift
@@ -70,6 +70,16 @@ final class InputSourceMappingTests: XCTestCase {
         XCTAssertEqual(survivors.map(\.inputSourceID), ["a"])
     }
 
+    func testSanitizedMappingsCoercesLanguageUnsupportedByStoredModel() throws {
+        let json = """
+        [{"id":"\(UUID().uuidString)","inputSourceID":"a","inputSourceDisplayName":"A",
+          "engine":"parakeet","parakeetModel":"englishOnly","language":"zh"}]
+        """
+        let survivors = Settings.sanitizedMappings(from: Data(json.utf8))
+        XCTAssertEqual(survivors.map(\.inputSourceID), ["a"])
+        XCTAssertEqual(survivors.first?.language, .english)
+    }
+
     func testSanitizedMappingsDropsParakeetEntryWithoutModel() throws {
         let json = """
         [{"id":"\(UUID().uuidString)","inputSourceID":"a","inputSourceDisplayName":"A",

--- a/Dictate AnywhereTests/InputSourceMappingTests.swift
+++ b/Dictate AnywhereTests/InputSourceMappingTests.swift
@@ -89,4 +89,118 @@ final class InputSourceMappingTests: XCTestCase {
         let data = try XCTUnwrap(UserDefaults.standard.data(forKey: "inputSourceMappings"))
         XCTAssertEqual(Settings.sanitizedMappings(from: data), [mapping])
     }
+
+    // MARK: - Mutation helpers
+
+    func testAddMappingDerivesDefaultsFromCurrentSettings() {
+        let settings = Settings.shared
+        settings.inputSourceMappings = []
+        settings.engineChoice = .parakeet
+        settings.parakeetModelChoice = .englishOnly
+
+        let mapping = settings.addInputSourceMapping(
+            inputSourceID: "com.apple.inputmethod.SCIM.ITABC",
+            displayName: "Pinyin – Simplified",
+            derivedLanguage: .chinese,
+            isModelDownloaded: { $0 == .senseVoice }
+        )
+
+        // englishOnly can't do Chinese; senseVoice is the downloaded model that can.
+        XCTAssertEqual(mapping?.engine, .parakeet)
+        XCTAssertEqual(mapping?.parakeetModel, .senseVoice)
+        XCTAssertEqual(mapping?.language, .chinese)
+        XCTAssertEqual(settings.inputSourceMappings.count, 1)
+    }
+
+    func testAddMappingKeepsCurrentModelWhenItSupportsDerivedLanguage() {
+        let settings = Settings.shared
+        settings.inputSourceMappings = []
+        settings.engineChoice = .parakeet
+        settings.parakeetModelChoice = .nemotronMultilingual
+
+        let mapping = settings.addInputSourceMapping(
+            inputSourceID: "com.apple.keylayout.German",
+            displayName: "German",
+            derivedLanguage: .german,
+            isModelDownloaded: { _ in false }
+        )
+
+        XCTAssertEqual(mapping?.parakeetModel, .nemotronMultilingual)
+        XCTAssertEqual(mapping?.language, .german)
+    }
+
+    func testAddMappingFallsBackToCurrentModelAndCoercesLanguage() {
+        let settings = Settings.shared
+        settings.inputSourceMappings = []
+        settings.engineChoice = .parakeet
+        settings.parakeetModelChoice = .englishOnly
+
+        // Nothing downloaded that supports Chinese -> keep current model, coerce language.
+        let mapping = settings.addInputSourceMapping(
+            inputSourceID: "com.apple.inputmethod.SCIM.ITABC",
+            displayName: "Pinyin – Simplified",
+            derivedLanguage: .chinese,
+            isModelDownloaded: { _ in false }
+        )
+
+        XCTAssertEqual(mapping?.parakeetModel, .englishOnly)
+        XCTAssertEqual(mapping?.language, .english)
+    }
+
+    func testAddMappingRejectsDuplicateInputSource() {
+        let settings = Settings.shared
+        settings.inputSourceMappings = [makeMapping(source: "dup")]
+
+        let second = settings.addInputSourceMapping(
+            inputSourceID: "dup", displayName: "Dup",
+            derivedLanguage: nil, isModelDownloaded: { _ in true }
+        )
+
+        XCTAssertNil(second)
+        XCTAssertEqual(settings.inputSourceMappings.count, 1)
+    }
+
+    func testUpdateCoercesLanguageUnsupportedByModel() {
+        let settings = Settings.shared
+        let mapping = makeMapping(model: .nemotronMultilingual, language: .chinese)
+        settings.inputSourceMappings = [mapping]
+
+        var edited = mapping
+        edited.parakeetModel = .englishOnly  // englishOnly can't do Chinese
+        settings.updateInputSourceMapping(edited)
+
+        XCTAssertEqual(settings.inputSourceMappings[0].parakeetModel, .englishOnly)
+        XCTAssertEqual(settings.inputSourceMappings[0].language, .english)
+    }
+
+    func testUpdateNormalizesModelForEngine() {
+        let settings = Settings.shared
+        settings.parakeetModelChoice = .multilingual
+        let mapping = makeMapping()
+        settings.inputSourceMappings = [mapping]
+
+        // Switching to Apple Speech clears the model…
+        var edited = mapping
+        edited.engine = .appleSpeech
+        settings.updateInputSourceMapping(edited)
+        XCTAssertNil(settings.inputSourceMappings[0].parakeetModel)
+
+        // …and switching back fills it from the current global choice.
+        edited = settings.inputSourceMappings[0]
+        edited.engine = .parakeet
+        settings.updateInputSourceMapping(edited)
+        XCTAssertEqual(settings.inputSourceMappings[0].parakeetModel, .multilingual)
+    }
+
+    func testRemoveAndLookup() {
+        let settings = Settings.shared
+        let mapping = makeMapping(source: "findme")
+        settings.inputSourceMappings = [mapping]
+
+        XCTAssertEqual(settings.mapping(forInputSourceID: "findme"), mapping)
+        XCTAssertNil(settings.mapping(forInputSourceID: "absent"))
+
+        settings.removeInputSourceMapping(id: mapping.id)
+        XCTAssertTrue(settings.inputSourceMappings.isEmpty)
+    }
 }

--- a/Dictate AnywhereTests/InputSourceMappingTests.swift
+++ b/Dictate AnywhereTests/InputSourceMappingTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+@testable import Dictate_Anywhere_Dev
+
+final class InputSourceMappingTests: XCTestCase {
+    private var savedMappings: [InputSourceMapping] = []
+    private var savedEnabled = false
+    private var savedEngineChoice: TranscriptionEngineChoice = .parakeet
+    private var savedModel: ParakeetModelChoice = .multilingual
+    private var savedLanguage: SupportedLanguage = .english
+    private var savedMode: TranscriptPostProcessingMode = .none
+
+    override func setUp() {
+        super.setUp()
+        let settings = Settings.shared
+        savedMappings = settings.inputSourceMappings
+        savedEnabled = settings.inputSourceAutoSwitchEnabled
+        savedEngineChoice = settings.engineChoice
+        savedModel = settings.parakeetModelChoice
+        savedLanguage = settings.selectedLanguage
+        savedMode = settings.transcriptPostProcessingMode
+    }
+
+    override func tearDown() {
+        let settings = Settings.shared
+        settings.inputSourceMappings = savedMappings
+        settings.inputSourceAutoSwitchEnabled = savedEnabled
+        // Model before language, post-processing mode last (didSet coercions).
+        settings.engineChoice = savedEngineChoice
+        settings.parakeetModelChoice = savedModel
+        settings.selectedLanguage = savedLanguage
+        settings.transcriptPostProcessingMode = savedMode
+        super.tearDown()
+    }
+
+    private func makeMapping(
+        source: String = "com.apple.keylayout.ABC",
+        engine: TranscriptionEngineChoice = .parakeet,
+        model: ParakeetModelChoice? = .englishOnly,
+        language: SupportedLanguage = .english
+    ) -> InputSourceMapping {
+        InputSourceMapping(
+            id: UUID(), inputSourceID: source, inputSourceDisplayName: "ABC",
+            engine: engine, parakeetModel: model, language: language
+        )
+    }
+
+    func testMappingsRoundTripThroughJSON() throws {
+        let mappings = [
+            makeMapping(),
+            makeMapping(source: "com.apple.inputmethod.SCIM.ITABC", model: .senseVoice, language: .chinese),
+        ]
+        let data = try JSONEncoder().encode(mappings)
+        XCTAssertEqual(Settings.sanitizedMappings(from: data), mappings)
+    }
+
+    func testSanitizedMappingsDropsUnknownEnumRawValues() throws {
+        let json = """
+        [
+          {"id":"\(UUID().uuidString)","inputSourceID":"a","inputSourceDisplayName":"A",
+           "engine":"parakeet","parakeetModel":"englishOnly","language":"en"},
+          {"id":"\(UUID().uuidString)","inputSourceID":"b","inputSourceDisplayName":"B",
+           "engine":"banana","parakeetModel":"englishOnly","language":"en"},
+          {"id":"\(UUID().uuidString)","inputSourceID":"c","inputSourceDisplayName":"C",
+           "engine":"parakeet","parakeetModel":"deletedModel","language":"en"},
+          {"id":"\(UUID().uuidString)","inputSourceID":"d","inputSourceDisplayName":"D",
+           "engine":"parakeet","parakeetModel":"englishOnly","language":"xx"}
+        ]
+        """
+        let survivors = Settings.sanitizedMappings(from: Data(json.utf8))
+        XCTAssertEqual(survivors.map(\.inputSourceID), ["a"])
+    }
+
+    func testSanitizedMappingsDropsParakeetEntryWithoutModel() throws {
+        let json = """
+        [{"id":"\(UUID().uuidString)","inputSourceID":"a","inputSourceDisplayName":"A",
+          "engine":"parakeet","language":"en"}]
+        """
+        XCTAssertTrue(Settings.sanitizedMappings(from: Data(json.utf8)).isEmpty)
+    }
+
+    func testSanitizedMappingsReturnsEmptyOnGarbageData() {
+        XCTAssertTrue(Settings.sanitizedMappings(from: Data("not json".utf8)).isEmpty)
+    }
+
+    func testMappingsPersistToUserDefaults() throws {
+        let settings = Settings.shared
+        let mapping = makeMapping()
+        settings.inputSourceMappings = [mapping]
+        let data = try XCTUnwrap(UserDefaults.standard.data(forKey: "inputSourceMappings"))
+        XCTAssertEqual(Settings.sanitizedMappings(from: data), [mapping])
+    }
+}

--- a/Dictate AnywhereTests/InputSourceMonitorTests.swift
+++ b/Dictate AnywhereTests/InputSourceMonitorTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import Dictate_Anywhere_Dev
+
+final class InputSourceMonitorTests: XCTestCase {
+    // MARK: - deriveLanguage (pure)
+
+    func testDeriveLanguageMatchesPrimarySubtag() {
+        XCTAssertEqual(InputSourceMonitor.deriveLanguage(fromBCP47: ["zh-Hans"]), .chinese)
+        XCTAssertEqual(InputSourceMonitor.deriveLanguage(fromBCP47: ["en-US"]), .english)
+        XCTAssertEqual(InputSourceMonitor.deriveLanguage(fromBCP47: ["de"]), .german)
+    }
+
+    func testDeriveLanguageMapsNorwegianBokmal() {
+        XCTAssertEqual(InputSourceMonitor.deriveLanguage(fromBCP47: ["nb"]), .norwegian)
+    }
+
+    func testDeriveLanguageReturnsNilForUnsupportedOrEmpty() {
+        XCTAssertNil(InputSourceMonitor.deriveLanguage(fromBCP47: ["ko"]))
+        XCTAssertNil(InputSourceMonitor.deriveLanguage(fromBCP47: []))
+    }
+
+    // MARK: - TIS queries (run against the real system in the test host)
+
+    @MainActor
+    func testCurrentInputSourceIDIsNonEmpty() {
+        let id = InputSourceMonitor().currentInputSourceID()
+        XCTAssertNotNil(id)
+        XCTAssertFalse(id?.isEmpty ?? true)
+    }
+
+    @MainActor
+    func testAvailableInputSourcesIncludesCurrent() {
+        let monitor = InputSourceMonitor()
+        guard let current = monitor.currentInputSourceID() else {
+            return XCTFail("No current input source")
+        }
+        let sources = monitor.availableInputSources()
+        XCTAssertFalse(sources.isEmpty)
+        XCTAssertTrue(sources.contains { $0.id == current })
+        XCTAssertTrue(sources.allSatisfy { !$0.localizedName.isEmpty })
+    }
+}

--- a/Dictate AnywhereTests/InputSourceProfileResolverTests.swift
+++ b/Dictate AnywhereTests/InputSourceProfileResolverTests.swift
@@ -22,7 +22,8 @@ final class InputSourceProfileResolverTests: XCTestCase {
         currentFluidAudioLanguage: SupportedLanguage = .english,
         currentAppleSpeechLanguage: SupportedLanguage = .english,
         appleSpeechSupported: Bool = true,
-        isModelDownloaded: @escaping (ParakeetModelChoice) -> Bool = { _ in true }
+        isModelDownloaded: @escaping (ParakeetModelChoice) -> Bool = { _ in true },
+        isAppleSpeechAssetInstalled: @escaping (SupportedLanguage) -> Bool = { _ in true }
     ) -> InputSourceProfileResolution {
         InputSourceProfileResolver.resolve(
             mapping: mapping,
@@ -32,7 +33,8 @@ final class InputSourceProfileResolverTests: XCTestCase {
             currentFluidAudioLanguage: currentFluidAudioLanguage,
             currentAppleSpeechLanguage: currentAppleSpeechLanguage,
             appleSpeechSupported: appleSpeechSupported,
-            isModelDownloaded: isModelDownloaded
+            isModelDownloaded: isModelDownloaded,
+            isAppleSpeechAssetInstalled: isAppleSpeechAssetInstalled
         )
     }
 
@@ -106,5 +108,32 @@ final class InputSourceProfileResolverTests: XCTestCase {
             .fullApply
         )
         XCTAssertEqual(resolve(mapping: mapping(), currentEngine: .appleSpeech), .fullApply)
+    }
+
+    // MARK: - Apple Speech installed-asset gate
+
+    func testAppleSpeechMappingWithAssetNotInstalledResolvesToInactive() {
+        // Would otherwise be `.noChange` (engine/language already match), but
+        // auto-switching must never trigger a silent asset download.
+        XCTAssertEqual(
+            resolve(
+                mapping: mapping(engine: .appleSpeech, model: nil, language: .german),
+                currentEngine: .appleSpeech,
+                currentAppleSpeechLanguage: .german,
+                isAppleSpeechAssetInstalled: { _ in false }
+            ),
+            .inactive
+        )
+    }
+
+    func testAppleSpeechMappingWithAssetInstalledPreservesPriorBehavior() {
+        XCTAssertEqual(
+            resolve(
+                mapping: mapping(engine: .appleSpeech, model: nil),
+                currentEngine: .parakeet,
+                isAppleSpeechAssetInstalled: { _ in true }
+            ),
+            .fullApply
+        )
     }
 }

--- a/Dictate AnywhereTests/InputSourceProfileResolverTests.swift
+++ b/Dictate AnywhereTests/InputSourceProfileResolverTests.swift
@@ -1,0 +1,110 @@
+import XCTest
+@testable import Dictate_Anywhere_Dev
+
+/// Pure resolution tests — no Settings.shared mutation, no snapshot needed.
+final class InputSourceProfileResolverTests: XCTestCase {
+    private func mapping(
+        engine: TranscriptionEngineChoice = .parakeet,
+        model: ParakeetModelChoice? = .senseVoice,
+        language: SupportedLanguage = .chinese
+    ) -> InputSourceMapping {
+        InputSourceMapping(
+            id: UUID(), inputSourceID: "src", inputSourceDisplayName: "Src",
+            engine: engine, parakeetModel: model, language: language
+        )
+    }
+
+    private func resolve(
+        mapping: InputSourceMapping?,
+        enabled: Bool = true,
+        currentEngine: TranscriptionEngineChoice = .parakeet,
+        currentParakeetModel: ParakeetModelChoice = .englishOnly,
+        currentFluidAudioLanguage: SupportedLanguage = .english,
+        currentAppleSpeechLanguage: SupportedLanguage = .english,
+        appleSpeechSupported: Bool = true,
+        isModelDownloaded: @escaping (ParakeetModelChoice) -> Bool = { _ in true }
+    ) -> InputSourceProfileResolution {
+        InputSourceProfileResolver.resolve(
+            mapping: mapping,
+            enabled: enabled,
+            currentEngine: currentEngine,
+            currentParakeetModel: currentParakeetModel,
+            currentFluidAudioLanguage: currentFluidAudioLanguage,
+            currentAppleSpeechLanguage: currentAppleSpeechLanguage,
+            appleSpeechSupported: appleSpeechSupported,
+            isModelDownloaded: isModelDownloaded
+        )
+    }
+
+    func testDisabledOrUnmappedResolvesToNone() {
+        XCTAssertEqual(resolve(mapping: mapping(), enabled: false), InputSourceProfileResolution.none)
+        XCTAssertEqual(resolve(mapping: nil), InputSourceProfileResolution.none)
+    }
+
+    func testParakeetMappingWithoutModelResolvesToNone() {
+        XCTAssertEqual(resolve(mapping: mapping(model: nil)), InputSourceProfileResolution.none)
+    }
+
+    func testNotDownloadedModelResolvesToInactive() {
+        XCTAssertEqual(
+            resolve(mapping: mapping(), isModelDownloaded: { _ in false }),
+            .inactive
+        )
+    }
+
+    func testAppleSpeechMappingOnUnsupportedOSResolvesToInactive() {
+        XCTAssertEqual(
+            resolve(mapping: mapping(engine: .appleSpeech, model: nil), appleSpeechSupported: false),
+            .inactive
+        )
+    }
+
+    func testExactMatchResolvesToNoChange() {
+        XCTAssertEqual(
+            resolve(
+                mapping: mapping(),
+                currentParakeetModel: .senseVoice,
+                currentFluidAudioLanguage: .chinese
+            ),
+            .noChange
+        )
+        XCTAssertEqual(
+            resolve(
+                mapping: mapping(engine: .appleSpeech, model: nil, language: .german),
+                currentEngine: .appleSpeech,
+                currentAppleSpeechLanguage: .german
+            ),
+            .noChange
+        )
+    }
+
+    func testSameModelDifferentLanguageResolvesToLanguageOnly() {
+        XCTAssertEqual(
+            resolve(
+                mapping: mapping(model: .nemotronMultilingual, language: .chinese),
+                currentParakeetModel: .nemotronMultilingual,
+                currentFluidAudioLanguage: .english
+            ),
+            .languageOnly(.chinese)
+        )
+        XCTAssertEqual(
+            resolve(
+                mapping: mapping(engine: .appleSpeech, model: nil, language: .german),
+                currentEngine: .appleSpeech,
+                currentAppleSpeechLanguage: .english
+            ),
+            .languageOnly(.german)
+        )
+    }
+
+    func testEngineOrModelMismatchResolvesToFullApply() {
+        // Model mismatch on the same engine.
+        XCTAssertEqual(resolve(mapping: mapping()), .fullApply)
+        // Engine mismatch, both directions.
+        XCTAssertEqual(
+            resolve(mapping: mapping(engine: .appleSpeech, model: nil), currentEngine: .parakeet),
+            .fullApply
+        )
+        XCTAssertEqual(resolve(mapping: mapping(), currentEngine: .appleSpeech), .fullApply)
+    }
+}

--- a/Dictate AnywhereTests/ModelSwitchBenchmarkTests.swift
+++ b/Dictate AnywhereTests/ModelSwitchBenchmarkTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import Dictate_Anywhere_Dev
+
+/// Warm-cache model switch timings. Gated behind RUN_MODEL_SWITCH_BENCHMARK=1
+/// because it loads real CoreML models from the app's model cache.
+final class ModelSwitchBenchmarkTests: XCTestCase {
+    private var savedEngineChoice: TranscriptionEngineChoice = .parakeet
+    private var savedModel: ParakeetModelChoice = .multilingual
+    private var savedLanguage: SupportedLanguage = .english
+    private var savedMode: TranscriptPostProcessingMode = .none
+
+    override func setUp() {
+        super.setUp()
+        let settings = Settings.shared
+        savedEngineChoice = settings.engineChoice
+        savedModel = settings.parakeetModelChoice
+        savedLanguage = settings.selectedLanguage
+        savedMode = settings.transcriptPostProcessingMode
+    }
+
+    override func tearDown() {
+        let settings = Settings.shared
+        // Model before language, post-processing mode last (didSet coercions).
+        settings.engineChoice = savedEngineChoice
+        settings.parakeetModelChoice = savedModel
+        settings.selectedLanguage = savedLanguage
+        settings.transcriptPostProcessingMode = savedMode
+        super.tearDown()
+    }
+
+    @MainActor
+    func testModelSwitchTimings() async throws {
+        try XCTSkipUnless(
+            ProcessInfo.processInfo.environment["RUN_MODEL_SWITCH_BENCHMARK"] == "1",
+            "Set RUN_MODEL_SWITCH_BENCHMARK=1 to run the model switch benchmark"
+        )
+        let engine = ParakeetEngine()
+        let settings = Settings.shared
+        settings.engineChoice = .parakeet
+
+        let candidates: [ParakeetModelChoice] = [
+            .englishOnly, .senseVoice, .englishOnly, .nemotronMultilingual, .senseVoice,
+        ]
+        let sequence = candidates.filter { engine.checkModelOnDisk(for: $0) }
+        try XCTSkipUnless(
+            Set(sequence).count >= 2,
+            "Need at least two downloaded models among \(candidates.map(\.rawValue))"
+        )
+
+        let clock = ContinuousClock()
+        for target in sequence {
+            settings.parakeetModelChoice = target
+            await engine.handleSelectedModelChange()
+            let elapsed = try await clock.measure {
+                try await engine.prepare()
+            }
+            print("MODEL_SWITCH_BENCHMARK \(target.rawValue): \(elapsed)")
+        }
+    }
+}

--- a/Dictate AnywhereTests/SettingsLogicTests.swift
+++ b/Dictate AnywhereTests/SettingsLogicTests.swift
@@ -13,6 +13,7 @@ final class SettingsLogicTests: XCTestCase {
     private var savedEngineChoice: TranscriptionEngineChoice = .parakeet
     private var savedParakeetModelChoice: ParakeetModelChoice = .multilingual
     private var savedSelectedLanguage: SupportedLanguage = .english
+    private var savedPendingVocabularyModeRestore = false
 
     override func setUp() {
         super.setUp()
@@ -25,6 +26,7 @@ final class SettingsLogicTests: XCTestCase {
         savedEngineChoice = settings.engineChoice
         savedParakeetModelChoice = settings.parakeetModelChoice
         savedSelectedLanguage = settings.selectedLanguage
+        savedPendingVocabularyModeRestore = settings.pendingVocabularyModeRestore
     }
 
     override func tearDown() {
@@ -33,6 +35,7 @@ final class SettingsLogicTests: XCTestCase {
         settings.fillerWordsToRemove = savedFillerWords
         settings.transcriptHistory = savedHistory
         settings.hotkeyBindings = savedBindings
+        settings.pendingVocabularyModeRestore = savedPendingVocabularyModeRestore
         // Restore engine/model choice before post-processing mode: both
         // carry didSet coercions that can rewrite `transcriptPostProcessingMode`
         // (and `selectedLanguage`), so mode must be restored last to avoid
@@ -216,5 +219,111 @@ final class SettingsLogicTests: XCTestCase {
         // model selected must coerce the mode back to `.none`.
         settings.engineChoice = .parakeet
         XCTAssertEqual(settings.transcriptPostProcessingMode, .none)
+    }
+
+    // MARK: - Pending vocabulary mode restore (auto-switch)
+
+    func testNoteAutoSwitchModelChangeSetsFlagOnlyWhenModeWasStripped() {
+        let settings = Settings.shared
+
+        // Simulate the coercion having fired: mode was `.fluidAudioVocabulary`
+        // before the auto-switch write, and is no longer that after.
+        settings.pendingVocabularyModeRestore = false
+        settings.transcriptPostProcessingMode = .none
+        settings.noteAutoSwitchModelChange(hadVocabularyMode: true)
+        XCTAssertTrue(settings.pendingVocabularyModeRestore)
+    }
+
+    func testNoteAutoSwitchModelChangeNoOpsWhenHadVocabularyModeIsFalse() {
+        let settings = Settings.shared
+
+        settings.pendingVocabularyModeRestore = false
+        settings.transcriptPostProcessingMode = .none
+        settings.noteAutoSwitchModelChange(hadVocabularyMode: false)
+        XCTAssertFalse(settings.pendingVocabularyModeRestore)
+    }
+
+    func testNoteAutoSwitchModelChangeNoOpsWhenModeStillFluidAudioVocabulary() {
+        let settings = Settings.shared
+
+        // Coercion didn't fire (e.g. destination was still vocab-capable).
+        settings.pendingVocabularyModeRestore = false
+        settings.transcriptPostProcessingMode = .fluidAudioVocabulary
+        settings.noteAutoSwitchModelChange(hadVocabularyMode: true)
+        XCTAssertFalse(settings.pendingVocabularyModeRestore)
+    }
+
+    func testRestoreVocabularyModeRestoresAndClearsWhenModelCapable() {
+        let settings = Settings.shared
+
+        settings.engineChoice = .parakeet
+        settings.parakeetModelChoice = .multilingual
+        XCTAssertTrue(settings.parakeetModelChoice.supportsFluidAudioVocabulary)
+        settings.transcriptPostProcessingMode = .none
+        settings.pendingVocabularyModeRestore = true
+
+        settings.restoreVocabularyModeAfterAutoSwitchIfPending()
+
+        XCTAssertEqual(settings.transcriptPostProcessingMode, .fluidAudioVocabulary)
+        XCTAssertFalse(settings.pendingVocabularyModeRestore)
+    }
+
+    func testRestoreVocabularyModeKeepsFlagPendingWhenModelNotCapable() {
+        let settings = Settings.shared
+
+        settings.engineChoice = .parakeet
+        settings.parakeetModelChoice = .senseVoice
+        XCTAssertFalse(settings.parakeetModelChoice.supportsFluidAudioVocabulary)
+        // Coerced to .none as a side effect of the assignment above; confirm
+        // the starting point explicitly.
+        settings.transcriptPostProcessingMode = .none
+        settings.pendingVocabularyModeRestore = true
+
+        settings.restoreVocabularyModeAfterAutoSwitchIfPending()
+
+        XCTAssertEqual(settings.transcriptPostProcessingMode, .none)
+        XCTAssertTrue(settings.pendingVocabularyModeRestore)
+    }
+
+    func testRestoreVocabularyModeClearsWithoutChangingModeWhenUserPickedAnotherMode() {
+        let settings = Settings.shared
+
+        settings.engineChoice = .parakeet
+        settings.parakeetModelChoice = .multilingual
+        settings.transcriptPostProcessingMode = .ollama
+        settings.pendingVocabularyModeRestore = true
+
+        settings.restoreVocabularyModeAfterAutoSwitchIfPending()
+
+        XCTAssertEqual(settings.transcriptPostProcessingMode, .ollama)
+        XCTAssertFalse(settings.pendingVocabularyModeRestore)
+    }
+
+    func testRestoreVocabularyModeClearsWhenModeAlreadyFluidAudioVocabulary() {
+        let settings = Settings.shared
+
+        settings.engineChoice = .parakeet
+        settings.parakeetModelChoice = .multilingual
+        settings.transcriptPostProcessingMode = .fluidAudioVocabulary
+        settings.pendingVocabularyModeRestore = true
+
+        settings.restoreVocabularyModeAfterAutoSwitchIfPending()
+
+        XCTAssertEqual(settings.transcriptPostProcessingMode, .fluidAudioVocabulary)
+        XCTAssertFalse(settings.pendingVocabularyModeRestore)
+    }
+
+    func testRestoreVocabularyModeNoOpWhenFlagNotPending() {
+        let settings = Settings.shared
+
+        settings.engineChoice = .parakeet
+        settings.parakeetModelChoice = .multilingual
+        settings.transcriptPostProcessingMode = .none
+        settings.pendingVocabularyModeRestore = false
+
+        settings.restoreVocabularyModeAfterAutoSwitchIfPending()
+
+        XCTAssertEqual(settings.transcriptPostProcessingMode, .none)
+        XCTAssertFalse(settings.pendingVocabularyModeRestore)
     }
 }


### PR DESCRIPTION
## Summary

This PR makes dictation follow the macOS keyboard input source: switch to Pinyin (or any mapped layout) and the app automatically applies your configured engine, speech model, and transcription language before you start talking.

Builds on #15 (branched from `mandarin-voice-input`), will rebase once #15 is merged in . 

**Approach**:

- **Input source detection** via the Carbon Text Input Sources API — a small monitor observes `kTISNotifySelectedKeyboardInputSourceChanged` on the distributed notification center (debounced, no extra permissions needed)
- **Per-source mappings** in General settings: each enabled input source can map to an engine + model + language, behind an opt-in toggle, with rows modeled on the existing shortcuts UI. New mappings pre-fill their language from the input source's declared BCP-47 codes
- **Eager pre-warm**: profiles apply while the app is idle so the model is already loaded when dictation starts; a recording-start backstop re-checks and shows a "Loading model…" overlay pill for the rare in-flight load (warm-cache switches measured ~90–270 ms via a new gated benchmark)
- **Never downloads anything**: mappings to models not on disk — or Apple Speech languages whose assets aren't installed — resolve inactive with a settings hint instead of triggering a download
- **No duplicated capability data**: language/model rules flow from the existing `ParakeetModelChoice` / Apple Speech APIs; the mapping layer stores no language tables, so future model changes propagate automatically
- **Quality-of-life**: FluidAudio vocabulary post-processing is restored when auto-switching back to a model that supports it, and stored mappings are sanitized against model/language changes across app versions
- Testing: 36 new unit tests (mapping persistence and coercion, a pure profile resolver, BCP-47 language derivation) plus an env-gated model-switch timing benchmark; the default suite stays fast and offline

## Status

- [x] Implementation
- [x] Unit tests
- [x] Manual test checklist

🤖 Generated with [Claude Code](https://claude.com/claude-code)