### PR TITLE
Show the dictation overlay on the display being typed into

### DIFF
--- a/Dictate Anywhere/AccessibilityMessagingTimeout.swift
+++ b/Dictate Anywhere/AccessibilityMessagingTimeout.swift
@@ -1,0 +1,32 @@
+//
+//  AccessibilityMessagingTimeout.swift
+//  Dictate Anywhere
+//
+//  Scoped accessibility messaging timeout.
+//
+
+import Foundation
+
+/// Applies an accessibility messaging timeout for the duration of one call and
+/// restores the process default afterwards.
+///
+/// `AXUIElementSetMessagingTimeout` on the system-wide element sets the timeout
+/// "globally for this process": every accessibility read the app makes
+/// afterwards inherits it, including `TextInserter`'s, which talk to apps that
+/// are legitimately slow to answer. Passing 0 resets the global timeout to its
+/// default, so a short timeout taken for one lookup has to be given back.
+enum AccessibilityMessagingTimeout {
+    /// Runs `body` under `seconds`, then restores the process default.
+    ///
+    /// The restore runs on every exit path, so neither a thrown error nor an
+    /// early return can leak the shortened timeout into unrelated work.
+    static func withTimeout<T>(
+        _ seconds: Float,
+        apply: (Float) -> Void,
+        during body: () throws -> T
+    ) rethrows -> T {
+        apply(seconds)
+        defer { apply(0) }
+        return try body()
+    }
+}

--- a/Dictate Anywhere/AppState.swift
+++ b/Dictate Anywhere/AppState.swift
@@ -845,9 +845,11 @@ final class AppState {
         guard let frontmost = NSWorkspace.shared.frontmostApplication,
               frontmost.processIdentifier != currentPID else {
             insertionTargetApp = nil
+            overlay.beginSession(targetProcessIdentifier: nil)
             return
         }
         insertionTargetApp = frontmost
+        overlay.beginSession(targetProcessIdentifier: frontmost.processIdentifier)
     }
 
     private func reactivateInsertionTargetIfNeeded() async {

--- a/Dictate Anywhere/OverlayScreenPicker.swift
+++ b/Dictate Anywhere/OverlayScreenPicker.swift
@@ -1,0 +1,61 @@
+//
+//  OverlayScreenPicker.swift
+//  Dictate Anywhere
+//
+//  Display selection math for the dictation overlay.
+//
+//  Kept free of AppKit types so the multi-display arithmetic is testable
+//  without attaching real monitors.
+//
+
+import CoreGraphics
+
+enum OverlayScreenPicker {
+    /// Index of the display the overlay belongs on.
+    ///
+    /// `NSScreen.main` is unusable here: it means "screen with *our* key
+    /// window", and this app dictates into other apps from an accessory
+    /// activation policy, so it has no key window and AppKit falls back to the
+    /// primary display. Follow the text instead — the focused field first, the
+    /// pointer next, the primary display only as a last resort.
+    ///
+    /// - Parameters:
+    ///   - screenFrames: Display frames in AppKit global coordinates, primary first.
+    ///   - focusPoint: The focused text field's location, if accessibility could resolve it.
+    ///   - mouseLocation: The pointer's location, if known.
+    /// - Returns: An index into `screenFrames`, or nil when there are no displays.
+    static func pickScreenIndex(screenFrames: [CGRect], focusPoint: CGPoint?, mouseLocation: CGPoint?) -> Int? {
+        guard !screenFrames.isEmpty else { return nil }
+
+        if let focusPoint, let index = screenFrames.firstIndex(where: { $0.contains(focusPoint) }) {
+            return index
+        }
+
+        if let mouseLocation, let index = screenFrames.firstIndex(where: { $0.contains(mouseLocation) }) {
+            return index
+        }
+
+        return 0
+    }
+
+    /// Converts an Accessibility point into AppKit global coordinates.
+    ///
+    /// Accessibility measures downward from the top-left of the primary
+    /// display; AppKit measures upward from its bottom-left. Displays stacked
+    /// above the primary therefore report negative accessibility y values.
+    static func appKitPoint(fromAccessibilityPoint point: CGPoint, primaryFrame: CGRect) -> CGPoint {
+        CGPoint(x: point.x, y: primaryFrame.maxY - point.y)
+    }
+
+    /// Bottom-centered origin for the overlay within a display's visible frame.
+    ///
+    /// Works for any display position because `visibleFrame` is already in
+    /// global coordinates, including the negative origins of displays arranged
+    /// left of or below the primary.
+    static func overlayOrigin(inVisibleFrame visibleFrame: CGRect, size: CGSize, bottomMargin: CGFloat) -> CGPoint {
+        CGPoint(
+            x: visibleFrame.origin.x + (visibleFrame.width - size.width) / 2,
+            y: visibleFrame.origin.y + bottomMargin
+        )
+    }
+}

--- a/Dictate Anywhere/OverlayScreenResolver.swift
+++ b/Dictate Anywhere/OverlayScreenResolver.swift
@@ -12,15 +12,16 @@ import AppKit
 /// Split out of `OverlayWindow` so the once-per-session lookup can be tested
 /// without attaching monitors or granting accessibility permission.
 protocol OverlayScreenResolving {
-    /// Visible frames of the attached displays, primary first, in AppKit global
-    /// coordinates. Cheap enough to read on every overlay update.
-    func visibleFrames() -> [CGRect]
+    /// The attached displays, primary first, with visible frames in AppKit
+    /// global coordinates. Cheap enough to read on every overlay update.
+    func displays() -> [OverlayDisplay]
 
-    /// Index of the display the overlay belongs on, or nil when none matches.
+    /// Expensive: this is the call that crosses a process boundary to ask an
+    /// application where it is, so callers resolve once per dictation.
     ///
-    /// Expensive: this is the call that crosses a process boundary to ask the
-    /// focused application where it is, so callers resolve once per session.
-    func resolveScreenIndex() -> Int?
+    /// - Parameter processIdentifier: the app the transcript will be pasted
+    ///   into, or nil to follow whichever app is frontmost.
+    func resolveDisplayID(forApplication processIdentifier: pid_t?) -> CGDirectDisplayID?
 }
 
 /// Resolves the overlay's display from the real window server.
@@ -29,16 +30,24 @@ struct SystemOverlayScreenResolver: OverlayScreenResolving {
     /// unresponsive app must never block the main thread for long.
     private static let messagingTimeout: Float = 0.25
 
-    func visibleFrames() -> [CGRect] {
-        NSScreen.screens.map(\.visibleFrame)
+    func displays() -> [OverlayDisplay] {
+        NSScreen.screens.map {
+            OverlayDisplay(id: $0.displayID, visibleFrame: $0.visibleFrame)
+        }
     }
 
-    func resolveScreenIndex() -> Int? {
-        OverlayScreenPicker.pickScreenIndex(
-            screenFrames: NSScreen.screens.map(\.frame),
-            focusPoint: focusedLocation(),
+    func resolveDisplayID(forApplication processIdentifier: pid_t?) -> CGDirectDisplayID? {
+        let screens = NSScreen.screens
+
+        guard let index = OverlayScreenPicker.pickScreenIndex(
+            screenFrames: screens.map(\.frame),
+            focusPoint: focusedLocation(forApplication: processIdentifier),
             mouseLocation: NSEvent.mouseLocation
-        )
+        ) else {
+            return nil
+        }
+
+        return screens[index].displayID
     }
 
     // MARK: - Focus lookup
@@ -47,21 +56,21 @@ struct SystemOverlayScreenResolver: OverlayScreenResolving {
     /// lands on the display being dictated into. Nil when accessibility is
     /// unavailable or the focused app reports no usable geometry.
     ///
-    /// Everything here is asked of the frontmost application specifically.
-    /// The system-wide element's `kAXFocusedUIElement` looks like the obvious
-    /// way to do this and is not usable: it has been observed returning a stale
-    /// element belonging to a different process entirely — Terminal's text area
-    /// while Firefox was frontmost, on the opposite display — which would put
-    /// the overlay on a screen the dictated text is not going to. Dictation
-    /// pastes into the frontmost app, so the frontmost app is what to follow.
-    private func focusedLocation() -> CGPoint? {
+    /// Everything here is asked of one specific application. The system-wide
+    /// element's `kAXFocusedUIElement` looks like the obvious way to do this
+    /// and is not usable: it has been observed returning a stale element
+    /// belonging to a different process entirely — Terminal's text area while
+    /// Firefox was frontmost, on the opposite display — which would put the
+    /// overlay on a screen the dictated text is not going to.
+    private func focusedLocation(forApplication processIdentifier: pid_t?) -> CGPoint? {
         guard let primaryFrame = NSScreen.screens.first?.frame,
-              let app = NSWorkspace.shared.frontmostApplication else { return nil }
+              let targetPid = processIdentifier ?? NSWorkspace.shared.frontmostApplication?.processIdentifier
+        else { return nil }
 
         // The timeout has to be set on the system-wide element; that is what
         // makes it apply to this process's messages, including the ones below.
         let systemWide = AXUIElementCreateSystemWide()
-        let application = AXUIElementCreateApplication(app.processIdentifier)
+        let application = AXUIElementCreateApplication(targetPid)
 
         let axPoint = AccessibilityMessagingTimeout.withTimeout(
             Self.messagingTimeout,
@@ -143,5 +152,14 @@ struct SystemOverlayScreenResolver: OverlayScreenResolving {
         }
 
         return position(of: windowValue as! AXUIElement)
+    }
+}
+
+private extension NSScreen {
+    /// The display's `CGDirectDisplayID`, which stays with the physical display
+    /// across reconfiguration.
+    var displayID: CGDirectDisplayID {
+        let key = NSDeviceDescriptionKey("NSScreenNumber")
+        return (deviceDescription[key] as? NSNumber)?.uint32Value ?? 0
     }
 }

--- a/Dictate Anywhere/OverlayScreenResolver.swift
+++ b/Dictate Anywhere/OverlayScreenResolver.swift
@@ -1,0 +1,118 @@
+//
+//  OverlayScreenResolver.swift
+//  Dictate Anywhere
+//
+//  Supplies the display geometry the dictation overlay places itself against.
+//
+
+import AppKit
+
+/// Source of the display information the overlay needs.
+///
+/// Split out of `OverlayWindow` so the once-per-session lookup can be tested
+/// without attaching monitors or granting accessibility permission.
+protocol OverlayScreenResolving {
+    /// Visible frames of the attached displays, primary first, in AppKit global
+    /// coordinates. Cheap enough to read on every overlay update.
+    func visibleFrames() -> [CGRect]
+
+    /// Index of the display the overlay belongs on, or nil when none matches.
+    ///
+    /// Expensive: this is the call that crosses a process boundary to ask the
+    /// focused application where it is, so callers resolve once per session.
+    func resolveScreenIndex() -> Int?
+}
+
+/// Resolves the overlay's display from the real window server.
+struct SystemOverlayScreenResolver: OverlayScreenResolving {
+    /// The overlay has to appear the instant the hotkey fires, so an
+    /// unresponsive app must never block the main thread for long.
+    private static let messagingTimeout: Float = 0.25
+
+    func visibleFrames() -> [CGRect] {
+        NSScreen.screens.map(\.visibleFrame)
+    }
+
+    func resolveScreenIndex() -> Int? {
+        OverlayScreenPicker.pickScreenIndex(
+            screenFrames: NSScreen.screens.map(\.frame),
+            focusPoint: focusedElementLocation(),
+            mouseLocation: NSEvent.mouseLocation
+        )
+    }
+
+    // MARK: - Focused element lookup
+
+    /// Global location of the control currently receiving keystrokes, so the
+    /// overlay lands on the display being dictated into. Nil when accessibility
+    /// is unavailable or the focused app reports no usable geometry.
+    private func focusedElementLocation() -> CGPoint? {
+        guard let primaryFrame = NSScreen.screens.first?.frame else { return nil }
+
+        let systemWide = AXUIElementCreateSystemWide()
+
+        let axPoint = AccessibilityMessagingTimeout.withTimeout(
+            Self.messagingTimeout,
+            apply: { _ = AXUIElementSetMessagingTimeout(systemWide, $0) }
+        ) { () -> CGPoint? in
+            guard let element = focusedElement(of: systemWide) else { return nil }
+            return position(of: element) ?? containingWindowPosition(of: element)
+        }
+
+        guard let axPoint else { return nil }
+
+        return OverlayScreenPicker.appKitPoint(fromAccessibilityPoint: axPoint, primaryFrame: primaryFrame)
+    }
+
+    private func focusedElement(of systemWide: AXUIElement) -> AXUIElement? {
+        var focusedElement: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            systemWide,
+            kAXFocusedUIElementAttribute as CFString,
+            &focusedElement
+        ) == .success,
+            let focusedElement,
+            CFGetTypeID(focusedElement) == AXUIElementGetTypeID() else {
+            return nil
+        }
+
+        return (focusedElement as! AXUIElement)
+    }
+
+    private func position(of element: AXUIElement) -> CGPoint? {
+        var positionValue: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            element,
+            kAXPositionAttribute as CFString,
+            &positionValue
+        ) == .success,
+            let positionValue,
+            CFGetTypeID(positionValue) == AXValueGetTypeID() else {
+            return nil
+        }
+
+        let axValue = positionValue as! AXValue
+        guard AXValueGetType(axValue) == .cgPoint else { return nil }
+
+        var point = CGPoint.zero
+        guard AXValueGetValue(axValue, .cgPoint, &point) else { return nil }
+        return point
+    }
+
+    /// Some apps expose no position on the focused element itself; its window
+    /// is a good enough stand-in for picking a display.
+    private func containingWindowPosition(of element: AXUIElement) -> CGPoint? {
+        var windowValue: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            element,
+            kAXWindowAttribute as CFString,
+            &windowValue
+        ) == .success,
+            let windowValue,
+            CFGetTypeID(windowValue) == AXUIElementGetTypeID() else {
+            return nil
+        }
+
+        return position(of: windowValue as! AXUIElement)
+    }
+}

--- a/Dictate Anywhere/OverlayScreenResolver.swift
+++ b/Dictate Anywhere/OverlayScreenResolver.swift
@@ -36,27 +36,38 @@ struct SystemOverlayScreenResolver: OverlayScreenResolving {
     func resolveScreenIndex() -> Int? {
         OverlayScreenPicker.pickScreenIndex(
             screenFrames: NSScreen.screens.map(\.frame),
-            focusPoint: focusedElementLocation(),
+            focusPoint: focusedLocation(),
             mouseLocation: NSEvent.mouseLocation
         )
     }
 
-    // MARK: - Focused element lookup
+    // MARK: - Focus lookup
 
-    /// Global location of the control currently receiving keystrokes, so the
-    /// overlay lands on the display being dictated into. Nil when accessibility
-    /// is unavailable or the focused app reports no usable geometry.
-    private func focusedElementLocation() -> CGPoint? {
-        guard let primaryFrame = NSScreen.screens.first?.frame else { return nil }
+    /// Global location of whatever is receiving keystrokes, so the overlay
+    /// lands on the display being dictated into. Nil when accessibility is
+    /// unavailable or the focused app reports no usable geometry.
+    ///
+    /// Everything here is asked of the frontmost application specifically.
+    /// The system-wide element's `kAXFocusedUIElement` looks like the obvious
+    /// way to do this and is not usable: it has been observed returning a stale
+    /// element belonging to a different process entirely — Terminal's text area
+    /// while Firefox was frontmost, on the opposite display — which would put
+    /// the overlay on a screen the dictated text is not going to. Dictation
+    /// pastes into the frontmost app, so the frontmost app is what to follow.
+    private func focusedLocation() -> CGPoint? {
+        guard let primaryFrame = NSScreen.screens.first?.frame,
+              let app = NSWorkspace.shared.frontmostApplication else { return nil }
 
+        // The timeout has to be set on the system-wide element; that is what
+        // makes it apply to this process's messages, including the ones below.
         let systemWide = AXUIElementCreateSystemWide()
+        let application = AXUIElementCreateApplication(app.processIdentifier)
 
         let axPoint = AccessibilityMessagingTimeout.withTimeout(
             Self.messagingTimeout,
             apply: { _ = AXUIElementSetMessagingTimeout(systemWide, $0) }
         ) { () -> CGPoint? in
-            guard let element = focusedElement(of: systemWide) else { return nil }
-            return position(of: element) ?? containingWindowPosition(of: element)
+            focusedElementPosition(in: application) ?? focusedWindowPosition(in: application)
         }
 
         guard let axPoint else { return nil }
@@ -64,19 +75,37 @@ struct SystemOverlayScreenResolver: OverlayScreenResolving {
         return OverlayScreenPicker.appKitPoint(fromAccessibilityPoint: axPoint, primaryFrame: primaryFrame)
     }
 
-    private func focusedElement(of systemWide: AXUIElement) -> AXUIElement? {
-        var focusedElement: CFTypeRef?
+    /// Position of the control receiving keystrokes, for apps that expose one.
+    private func focusedElementPosition(in application: AXUIElement) -> CGPoint? {
+        guard let element = copyElement(kAXFocusedUIElementAttribute, from: application) else { return nil }
+        return position(of: element) ?? containingWindowPosition(of: element)
+    }
+
+    /// Position of the application's focused window.
+    ///
+    /// Chromium- and Gecko-based apps — VS Code, Slack, Firefox, Electron apps
+    /// generally — keep their accessibility tree switched off until they detect
+    /// a screen reader, so `kAXFocusedUIElement` answers `kAXErrorNoValue` for
+    /// them however it is asked. Their windows are ordinary windows and stay
+    /// visible to accessibility, and a window is enough to choose a display.
+    private func focusedWindowPosition(in application: AXUIElement) -> CGPoint? {
+        guard let window = copyElement(kAXFocusedWindowAttribute, from: application) else { return nil }
+        return position(of: window)
+    }
+
+    private func copyElement(_ attribute: String, from element: AXUIElement) -> AXUIElement? {
+        var value: CFTypeRef?
         guard AXUIElementCopyAttributeValue(
-            systemWide,
-            kAXFocusedUIElementAttribute as CFString,
-            &focusedElement
+            element,
+            attribute as CFString,
+            &value
         ) == .success,
-            let focusedElement,
-            CFGetTypeID(focusedElement) == AXUIElementGetTypeID() else {
+            let value,
+            CFGetTypeID(value) == AXUIElementGetTypeID() else {
             return nil
         }
 
-        return (focusedElement as! AXUIElement)
+        return (value as! AXUIElement)
     }
 
     private func position(of element: AXUIElement) -> CGPoint? {

--- a/Dictate Anywhere/OverlayScreenSession.swift
+++ b/Dictate Anywhere/OverlayScreenSession.swift
@@ -2,53 +2,77 @@
 //  OverlayScreenSession.swift
 //  Dictate Anywhere
 //
-//  Holds the dictation overlay's chosen display for one visible session.
+//  Holds the dictation overlay's chosen display for one dictation.
 //
 
 import CoreGraphics
 
-/// Remembers which display the overlay picked, for as long as it stays up.
+/// One attached display, identified by something stabler than its position in
+/// the screen list.
+struct OverlayDisplay: Equatable {
+    /// `CGDirectDisplayID` — stable for a physical display across
+    /// reconfiguration, unlike an index into `NSScreen.screens`.
+    let id: CGDirectDisplayID
+    let visibleFrame: CGRect
+}
+
+/// Remembers which display the overlay chose, for the length of one dictation.
 ///
-/// Choosing a display is expensive — it crosses a process boundary to ask the
-/// focused application where it is — and `OverlayWindow` repositions itself on
-/// every update, which for the listening waveform is about thirty times a
-/// second. Choosing per update would put those synchronous calls on the main
-/// thread at that rate, stalling the UI whenever the target app is slow to
-/// answer, and would also let the overlay hop displays mid-sentence if the
-/// pointer wandered. So the display is chosen on the first update of a session
-/// and kept until the overlay hides.
+/// Choosing is expensive — it crosses a process boundary to ask the target
+/// application where it is — and `OverlayWindow` repositions itself on every
+/// update, which for the listening waveform is about thirty times a second.
+/// Choosing per update would put those synchronous calls on the main thread at
+/// that rate, stalling the UI whenever the target app is slow to answer, and
+/// would let the overlay hop displays mid-sentence if the pointer wandered.
 final class OverlayScreenSession {
     private let resolver: OverlayScreenResolving
-    private var chosenIndex: Int?
+    private var chosenDisplayID: CGDirectDisplayID?
+    private var targetProcessIdentifier: pid_t?
 
     init(resolver: OverlayScreenResolving = SystemOverlayScreenResolver()) {
         self.resolver = resolver
     }
 
-    /// Visible frame of this session's display, choosing one on first use.
+    /// Starts a dictation, discarding any display the previous one chose.
+    ///
+    /// - Parameter targetProcessIdentifier: the app the transcript will be
+    ///   pasted into, captured before audio startup. The overlay follows this
+    ///   app rather than whichever one happens to be frontmost by the time the
+    ///   microphone is live. Nil falls back to the frontmost app.
+    func begin(targetProcessIdentifier: pid_t?) {
+        self.targetProcessIdentifier = targetProcessIdentifier
+        chosenDisplayID = nil
+    }
+
+    /// Visible frame of this dictation's display, choosing one on first use.
     ///
     /// Display geometry itself is cheap and does shift while the overlay is up
     /// — the dock hides, the menu bar reveals — so it is re-read every time
     /// even though the choice of display is not.
     func visibleFrame() -> CGRect? {
-        let frames = resolver.visibleFrames()
+        let displays = resolver.displays()
 
-        // Reusing an index means it can go stale: a display unplugged
-        // mid-dictation would otherwise strand the overlay off-screen.
-        if let chosenIndex, chosenIndex < frames.count {
-            return frames[chosenIndex]
+        // Matching by display id rather than list position: unplugging a
+        // monitor or reordering displays shifts indices, and a stale index
+        // stays in range while naming a different physical display.
+        if let chosenDisplayID, let display = displays.first(where: { $0.id == chosenDisplayID }) {
+            return display.visibleFrame
         }
 
-        // Left uncached when nothing can be chosen, so a lookup that failed
-        // once does not leave the overlay unplaced for the whole session.
-        guard let index = resolver.resolveScreenIndex(), index < frames.count else { return nil }
+        // Left unchosen when nothing can be resolved, so a lookup that failed
+        // once does not leave the overlay unplaced for the whole dictation.
+        guard let resolvedID = resolver.resolveDisplayID(forApplication: targetProcessIdentifier),
+              let display = displays.first(where: { $0.id == resolvedID }) else {
+            return nil
+        }
 
-        chosenIndex = index
-        return frames[index]
+        chosenDisplayID = resolvedID
+        return display.visibleFrame
     }
 
-    /// Ends the session, so the next appearance chooses its display afresh.
+    /// Ends the dictation, so the next overlay chooses its display afresh.
     func end() {
-        chosenIndex = nil
+        chosenDisplayID = nil
+        targetProcessIdentifier = nil
     }
 }

--- a/Dictate Anywhere/OverlayScreenSession.swift
+++ b/Dictate Anywhere/OverlayScreenSession.swift
@@ -1,0 +1,54 @@
+//
+//  OverlayScreenSession.swift
+//  Dictate Anywhere
+//
+//  Holds the dictation overlay's chosen display for one visible session.
+//
+
+import CoreGraphics
+
+/// Remembers which display the overlay picked, for as long as it stays up.
+///
+/// Choosing a display is expensive — it crosses a process boundary to ask the
+/// focused application where it is — and `OverlayWindow` repositions itself on
+/// every update, which for the listening waveform is about thirty times a
+/// second. Choosing per update would put those synchronous calls on the main
+/// thread at that rate, stalling the UI whenever the target app is slow to
+/// answer, and would also let the overlay hop displays mid-sentence if the
+/// pointer wandered. So the display is chosen on the first update of a session
+/// and kept until the overlay hides.
+final class OverlayScreenSession {
+    private let resolver: OverlayScreenResolving
+    private var chosenIndex: Int?
+
+    init(resolver: OverlayScreenResolving = SystemOverlayScreenResolver()) {
+        self.resolver = resolver
+    }
+
+    /// Visible frame of this session's display, choosing one on first use.
+    ///
+    /// Display geometry itself is cheap and does shift while the overlay is up
+    /// — the dock hides, the menu bar reveals — so it is re-read every time
+    /// even though the choice of display is not.
+    func visibleFrame() -> CGRect? {
+        let frames = resolver.visibleFrames()
+
+        // Reusing an index means it can go stale: a display unplugged
+        // mid-dictation would otherwise strand the overlay off-screen.
+        if let chosenIndex, chosenIndex < frames.count {
+            return frames[chosenIndex]
+        }
+
+        // Left uncached when nothing can be chosen, so a lookup that failed
+        // once does not leave the overlay unplaced for the whole session.
+        guard let index = resolver.resolveScreenIndex(), index < frames.count else { return nil }
+
+        chosenIndex = index
+        return frames[index]
+    }
+
+    /// Ends the session, so the next appearance chooses its display afresh.
+    func end() {
+        chosenIndex = nil
+    }
+}

--- a/Dictate Anywhere/OverlayWindow.swift
+++ b/Dictate Anywhere/OverlayWindow.swift
@@ -106,12 +106,91 @@ final class OverlayWindow {
     }
 
     private func positionWindow() {
-        guard let screen = NSScreen.main, let win = window else { return }
+        guard let win = window else { return }
 
-        let frame = screen.visibleFrame
-        let x = frame.origin.x + (frame.width - canvasWidth) / 2
-        let y = frame.origin.y + bottomMargin
+        let screens = NSScreen.screens
+        guard let index = OverlayScreenPicker.pickScreenIndex(
+            screenFrames: screens.map(\.frame),
+            focusPoint: focusedElementLocation(),
+            mouseLocation: NSEvent.mouseLocation
+        ) else { return }
 
-        win.setFrame(NSRect(x: x, y: y, width: canvasWidth, height: canvasHeight), display: true, animate: false)
+        let size = NSSize(width: canvasWidth, height: canvasHeight)
+        let origin = OverlayScreenPicker.overlayOrigin(
+            inVisibleFrame: screens[index].visibleFrame,
+            size: size,
+            bottomMargin: bottomMargin
+        )
+
+        win.setFrame(NSRect(origin: origin, size: size), display: true, animate: false)
+    }
+
+    // MARK: - Focused element lookup
+
+    /// Global location of the control currently receiving keystrokes, so the
+    /// overlay lands on the display being dictated into. Nil when accessibility
+    /// is unavailable or the focused app reports no usable geometry.
+    private func focusedElementLocation() -> CGPoint? {
+        guard let primaryFrame = NSScreen.screens.first?.frame else { return nil }
+
+        let systemWide = AXUIElementCreateSystemWide()
+        // The overlay has to appear the instant the hotkey fires, so never let
+        // an unresponsive app block the main thread here.
+        AXUIElementSetMessagingTimeout(systemWide, 0.25)
+
+        var focusedElement: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            systemWide,
+            kAXFocusedUIElementAttribute as CFString,
+            &focusedElement
+        ) == .success,
+            let focusedElement,
+            CFGetTypeID(focusedElement) == AXUIElementGetTypeID() else {
+            return nil
+        }
+
+        let element = focusedElement as! AXUIElement
+        guard let axPoint = position(of: element) ?? containingWindowPosition(of: element) else {
+            return nil
+        }
+
+        return OverlayScreenPicker.appKitPoint(fromAccessibilityPoint: axPoint, primaryFrame: primaryFrame)
+    }
+
+    private func position(of element: AXUIElement) -> CGPoint? {
+        var positionValue: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            element,
+            kAXPositionAttribute as CFString,
+            &positionValue
+        ) == .success,
+            let positionValue,
+            CFGetTypeID(positionValue) == AXValueGetTypeID() else {
+            return nil
+        }
+
+        let axValue = positionValue as! AXValue
+        guard AXValueGetType(axValue) == .cgPoint else { return nil }
+
+        var point = CGPoint.zero
+        guard AXValueGetValue(axValue, .cgPoint, &point) else { return nil }
+        return point
+    }
+
+    /// Some apps expose no position on the focused element itself; its window
+    /// is a good enough stand-in for picking a display.
+    private func containingWindowPosition(of element: AXUIElement) -> CGPoint? {
+        var windowValue: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            element,
+            kAXWindowAttribute as CFString,
+            &windowValue
+        ) == .success,
+            let windowValue,
+            CFGetTypeID(windowValue) == AXUIElementGetTypeID() else {
+            return nil
+        }
+
+        return position(of: windowValue as! AXUIElement)
     }
 }

--- a/Dictate Anywhere/OverlayWindow.swift
+++ b/Dictate Anywhere/OverlayWindow.swift
@@ -30,15 +30,34 @@ final class OverlayWindow {
 
     // MARK: - Public
 
-    func show(state: OverlayState) {
+    /// Starts a dictation, so the overlay chooses its display afresh.
+    ///
+    /// - Parameter targetProcessIdentifier: the app the transcript will be
+    ///   pasted into, captured before audio startup so the overlay follows it
+    ///   rather than whichever app is frontmost once the microphone is live.
+    func beginSession(targetProcessIdentifier: pid_t?) {
         hideTask?.cancel()
         hideTask = nil
 
         if Thread.isMainThread {
-            showImpl(state: state)
+            screenSession.begin(targetProcessIdentifier: targetProcessIdentifier)
         } else {
             DispatchQueue.main.async { [weak self] in
-                self?.showImpl(state: state)
+                self?.screenSession.begin(targetProcessIdentifier: targetProcessIdentifier)
+            }
+        }
+    }
+
+    func show(state: OverlayState) {
+        let supersedesFinishingSession = hideTask != nil
+        hideTask?.cancel()
+        hideTask = nil
+
+        if Thread.isMainThread {
+            showImpl(state: state, startsNewSession: supersedesFinishingSession)
+        } else {
+            DispatchQueue.main.async { [weak self] in
+                self?.showImpl(state: state, startsNewSession: supersedesFinishingSession)
             }
         }
     }
@@ -53,6 +72,7 @@ final class OverlayWindow {
                 self?.hideImpl()
             }
         } else {
+            hideTask = nil
             if Thread.isMainThread {
                 hideImpl()
             } else {
@@ -65,7 +85,11 @@ final class OverlayWindow {
 
     // MARK: - Private
 
-    private func showImpl(state: OverlayState) {
+    private func showImpl(state: OverlayState, startsNewSession: Bool) {
+        if startsNewSession {
+            screenSession.end()
+        }
+
         if window == nil {
             window = createWindow()
             let content = OverlayContent(model: model)

--- a/Dictate Anywhere/OverlayWindow.swift
+++ b/Dictate Anywhere/OverlayWindow.swift
@@ -30,20 +30,30 @@ final class OverlayWindow {
 
     // MARK: - Public
 
+    /// Whether the overlay is currently presented.
+    var isVisible: Bool {
+        model.isVisible
+    }
+
     /// Starts a dictation, so the overlay chooses its display afresh.
     ///
     /// - Parameter targetProcessIdentifier: the app the transcript will be
     ///   pasted into, captured before audio startup so the overlay follows it
     ///   rather than whichever app is frontmost once the microphone is live.
     func beginSession(targetProcessIdentifier: pid_t?) {
+        // Cancelling the scheduled hide is what keeps it from resetting the
+        // session that is about to be pinned — but the previous dictation's
+        // badge is still on screen, and on the previous display. Dismiss it
+        // here rather than leaving it up for the whole of this dictation's
+        // startup, which is longer than the hide would have taken.
         hideTask?.cancel()
         hideTask = nil
 
         if Thread.isMainThread {
-            screenSession.begin(targetProcessIdentifier: targetProcessIdentifier)
+            beginSessionImpl(targetProcessIdentifier: targetProcessIdentifier)
         } else {
             DispatchQueue.main.async { [weak self] in
-                self?.screenSession.begin(targetProcessIdentifier: targetProcessIdentifier)
+                self?.beginSessionImpl(targetProcessIdentifier: targetProcessIdentifier)
             }
         }
     }
@@ -105,11 +115,23 @@ final class OverlayWindow {
         window?.orderFrontRegardless()
     }
 
+    private func beginSessionImpl(targetProcessIdentifier: pid_t?) {
+        dismissVisuals()
+        screenSession.begin(targetProcessIdentifier: targetProcessIdentifier)
+    }
+
     private func hideImpl() {
-        model.isVisible = false
+        dismissVisuals()
 
         // The next appearance is a new session and picks its display afresh.
         screenSession.end()
+    }
+
+    /// Takes the overlay off screen without touching the screen session, so
+    /// dismissing a finished dictation cannot clear the display a newly begun
+    /// one has already pinned.
+    private func dismissVisuals() {
+        model.isVisible = false
 
         // Allow fade-out animation to complete before removing window
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in

--- a/Dictate Anywhere/OverlayWindow.swift
+++ b/Dictate Anywhere/OverlayWindow.swift
@@ -20,6 +20,14 @@ final class OverlayWindow {
     private let canvasWidth: CGFloat = OverlayMetrics.size(320)
     private let canvasHeight: CGFloat = OverlayMetrics.size(200)
 
+    @ObservationIgnored private let screenSession: OverlayScreenSession
+
+    // MARK: - Init
+
+    init(screenResolver: OverlayScreenResolving = SystemOverlayScreenResolver()) {
+        screenSession = OverlayScreenSession(resolver: screenResolver)
+    }
+
     // MARK: - Public
 
     func show(state: OverlayState) {
@@ -76,6 +84,9 @@ final class OverlayWindow {
     private func hideImpl() {
         model.isVisible = false
 
+        // The next appearance is a new session and picks its display afresh.
+        screenSession.end()
+
         // Allow fade-out animation to complete before removing window
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
             guard let self else { return }
@@ -106,91 +117,18 @@ final class OverlayWindow {
     }
 
     private func positionWindow() {
-        guard let win = window else { return }
-
-        let screens = NSScreen.screens
-        guard let index = OverlayScreenPicker.pickScreenIndex(
-            screenFrames: screens.map(\.frame),
-            focusPoint: focusedElementLocation(),
-            mouseLocation: NSEvent.mouseLocation
-        ) else { return }
+        guard let win = window, let visibleFrame = screenSession.visibleFrame() else { return }
 
         let size = NSSize(width: canvasWidth, height: canvasHeight)
         let origin = OverlayScreenPicker.overlayOrigin(
-            inVisibleFrame: screens[index].visibleFrame,
+            inVisibleFrame: visibleFrame,
             size: size,
             bottomMargin: bottomMargin
         )
 
-        win.setFrame(NSRect(origin: origin, size: size), display: true, animate: false)
-    }
+        let frame = NSRect(origin: origin, size: size)
+        guard win.frame != frame else { return }
 
-    // MARK: - Focused element lookup
-
-    /// Global location of the control currently receiving keystrokes, so the
-    /// overlay lands on the display being dictated into. Nil when accessibility
-    /// is unavailable or the focused app reports no usable geometry.
-    private func focusedElementLocation() -> CGPoint? {
-        guard let primaryFrame = NSScreen.screens.first?.frame else { return nil }
-
-        let systemWide = AXUIElementCreateSystemWide()
-        // The overlay has to appear the instant the hotkey fires, so never let
-        // an unresponsive app block the main thread here.
-        AXUIElementSetMessagingTimeout(systemWide, 0.25)
-
-        var focusedElement: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(
-            systemWide,
-            kAXFocusedUIElementAttribute as CFString,
-            &focusedElement
-        ) == .success,
-            let focusedElement,
-            CFGetTypeID(focusedElement) == AXUIElementGetTypeID() else {
-            return nil
-        }
-
-        let element = focusedElement as! AXUIElement
-        guard let axPoint = position(of: element) ?? containingWindowPosition(of: element) else {
-            return nil
-        }
-
-        return OverlayScreenPicker.appKitPoint(fromAccessibilityPoint: axPoint, primaryFrame: primaryFrame)
-    }
-
-    private func position(of element: AXUIElement) -> CGPoint? {
-        var positionValue: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(
-            element,
-            kAXPositionAttribute as CFString,
-            &positionValue
-        ) == .success,
-            let positionValue,
-            CFGetTypeID(positionValue) == AXValueGetTypeID() else {
-            return nil
-        }
-
-        let axValue = positionValue as! AXValue
-        guard AXValueGetType(axValue) == .cgPoint else { return nil }
-
-        var point = CGPoint.zero
-        guard AXValueGetValue(axValue, .cgPoint, &point) else { return nil }
-        return point
-    }
-
-    /// Some apps expose no position on the focused element itself; its window
-    /// is a good enough stand-in for picking a display.
-    private func containingWindowPosition(of element: AXUIElement) -> CGPoint? {
-        var windowValue: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(
-            element,
-            kAXWindowAttribute as CFString,
-            &windowValue
-        ) == .success,
-            let windowValue,
-            CFGetTypeID(windowValue) == AXUIElementGetTypeID() else {
-            return nil
-        }
-
-        return position(of: windowValue as! AXUIElement)
+        win.setFrame(frame, display: true, animate: false)
     }
 }

--- a/Dictate AnywhereTests/AccessibilityMessagingTimeoutTests.swift
+++ b/Dictate AnywhereTests/AccessibilityMessagingTimeoutTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+@testable import Dictate_Anywhere_Dev
+
+/// The accessibility messaging timeout is process-global: the SDK documents
+/// that setting it on the system-wide element "sets the timeout globally for
+/// this process", and that passing 0 "resets the global timeout to its default
+/// value". A timeout left in place would silently shorten every later
+/// accessibility read the app makes — `TextInserter` talks to apps that are
+/// legitimately slow — and would surface there rather than anywhere near the
+/// overlay. These tests pin the restore to every exit path.
+final class AccessibilityMessagingTimeoutTests: XCTestCase {
+    private struct LookupFailure: Error {}
+
+    func testAppliesTheTimeoutBeforeRunningTheBody() {
+        var currentTimeout: Float?
+        var timeoutSeenByBody: Float?
+
+        AccessibilityMessagingTimeout.withTimeout(0.25, apply: { currentTimeout = $0 }) {
+            timeoutSeenByBody = currentTimeout
+        }
+
+        XCTAssertEqual(timeoutSeenByBody, 0.25)
+    }
+
+    func testRestoresTheProcessDefaultAfterTheBodySucceeds() {
+        var applied: [Float] = []
+
+        AccessibilityMessagingTimeout.withTimeout(0.25, apply: { applied.append($0) }) {}
+
+        XCTAssertEqual(applied, [0.25, 0])
+    }
+
+    func testRestoresTheProcessDefaultWhenTheBodyThrows() {
+        var applied: [Float] = []
+
+        XCTAssertThrowsError(
+            try AccessibilityMessagingTimeout.withTimeout(0.25, apply: { applied.append($0) }) {
+                throw LookupFailure()
+            }
+        )
+
+        XCTAssertEqual(applied, [0.25, 0])
+    }
+
+    /// The overlay's real failure mode is not a thrown error but an
+    /// accessibility read that comes back empty, which is what happens for apps
+    /// exposing no usable geometry.
+    func testRestoresTheProcessDefaultWhenTheBodyFindsNothing() {
+        var applied: [Float] = []
+
+        let location = AccessibilityMessagingTimeout.withTimeout(0.25, apply: { applied.append($0) }) {
+            CGPoint?.none
+        }
+
+        XCTAssertNil(location)
+        XCTAssertEqual(applied, [0.25, 0])
+    }
+
+    func testReturnsTheValueTheBodyProduced() {
+        let location = AccessibilityMessagingTimeout.withTimeout(0.25, apply: { _ in }) {
+            CGPoint(x: 12, y: 34)
+        }
+
+        XCTAssertEqual(location, CGPoint(x: 12, y: 34))
+    }
+}

--- a/Dictate AnywhereTests/OverlayScreenPickerTests.swift
+++ b/Dictate AnywhereTests/OverlayScreenPickerTests.swift
@@ -1,0 +1,136 @@
+import XCTest
+@testable import Dictate_Anywhere_Dev
+
+/// Tests for the display-selection math behind the dictation overlay.
+///
+/// The layout is a two-display desktop: the primary 1920x1080 display at the
+/// origin, and a secondary 1440x900 display placed to its left, which gives the
+/// secondary a negative x origin exactly like a real left-hand monitor.
+final class OverlayScreenPickerTests: XCTestCase {
+    private let primary = CGRect(x: 0, y: 0, width: 1920, height: 1080)
+    private let leftSecondary = CGRect(x: -1440, y: 0, width: 1440, height: 900)
+
+    private var screens: [CGRect] { [primary, leftSecondary] }
+
+    private var pointOnPrimary: CGPoint { CGPoint(x: 960, y: 540) }
+    private var pointOnSecondary: CGPoint { CGPoint(x: -720, y: 450) }
+
+    // MARK: - Screen selection
+
+    func testPicksScreenContainingFocusedTextField() {
+        let index = OverlayScreenPicker.pickScreenIndex(
+            screenFrames: screens,
+            focusPoint: pointOnSecondary,
+            mouseLocation: nil
+        )
+
+        XCTAssertEqual(index, 1)
+    }
+
+    func testPrefersFocusedTextFieldOverMousePointer() {
+        let index = OverlayScreenPicker.pickScreenIndex(
+            screenFrames: screens,
+            focusPoint: pointOnSecondary,
+            mouseLocation: pointOnPrimary
+        )
+
+        XCTAssertEqual(index, 1)
+    }
+
+    func testFallsBackToMousePointerWhenFocusIsUnavailable() {
+        let index = OverlayScreenPicker.pickScreenIndex(
+            screenFrames: screens,
+            focusPoint: nil,
+            mouseLocation: pointOnSecondary
+        )
+
+        XCTAssertEqual(index, 1)
+    }
+
+    func testFallsBackToMousePointerWhenFocusIsOffAllDisplays() {
+        let offscreen = CGPoint(x: 10_000, y: 10_000)
+
+        let index = OverlayScreenPicker.pickScreenIndex(
+            screenFrames: screens,
+            focusPoint: offscreen,
+            mouseLocation: pointOnSecondary
+        )
+
+        XCTAssertEqual(index, 1)
+    }
+
+    func testFallsBackToPrimaryWhenNoPointMatchesADisplay() {
+        let offscreen = CGPoint(x: 10_000, y: 10_000)
+
+        let index = OverlayScreenPicker.pickScreenIndex(
+            screenFrames: screens,
+            focusPoint: offscreen,
+            mouseLocation: offscreen
+        )
+
+        XCTAssertEqual(index, 0)
+    }
+
+    func testReturnsNilWhenThereAreNoDisplays() {
+        let index = OverlayScreenPicker.pickScreenIndex(
+            screenFrames: [],
+            focusPoint: pointOnPrimary,
+            mouseLocation: pointOnPrimary
+        )
+
+        XCTAssertNil(index)
+    }
+
+    // MARK: - Accessibility coordinate conversion
+
+    func testAccessibilityPointFlipsIntoAppKitCoordinates() {
+        // AX measures down from the top-left of the primary display; AppKit
+        // measures up from its bottom-left.
+        let converted = OverlayScreenPicker.appKitPoint(
+            fromAccessibilityPoint: CGPoint(x: 300, y: 80),
+            primaryFrame: primary
+        )
+
+        XCTAssertEqual(converted.x, 300)
+        XCTAssertEqual(converted.y, 1000)
+    }
+
+    func testAccessibilityPointAboveThePrimaryDisplayConvertsToPositiveY() {
+        // A display stacked above the primary reports negative AX y values.
+        let converted = OverlayScreenPicker.appKitPoint(
+            fromAccessibilityPoint: CGPoint(x: 100, y: -600),
+            primaryFrame: primary
+        )
+
+        XCTAssertEqual(converted.y, 1680)
+    }
+
+    // MARK: - Overlay placement
+
+    func testOverlayOriginIsBottomCenteredOnTheChosenDisplay() {
+        let visibleFrame = CGRect(x: 0, y: 25, width: 1920, height: 1030)
+
+        let origin = OverlayScreenPicker.overlayOrigin(
+            inVisibleFrame: visibleFrame,
+            size: CGSize(width: 208, height: 130),
+            bottomMargin: 16
+        )
+
+        XCTAssertEqual(origin.x, 856)
+        XCTAssertEqual(origin.y, 41)
+    }
+
+    func testOverlayOriginStaysOnADisplayWithANegativeOrigin() {
+        let visibleFrame = CGRect(x: -1440, y: 0, width: 1440, height: 875)
+
+        let origin = OverlayScreenPicker.overlayOrigin(
+            inVisibleFrame: visibleFrame,
+            size: CGSize(width: 208, height: 130),
+            bottomMargin: 16
+        )
+
+        XCTAssertEqual(origin.x, -824)
+        XCTAssertEqual(origin.y, 16)
+        XCTAssertTrue(visibleFrame.contains(CGPoint(x: origin.x, y: origin.y)))
+    }
+}

--- a/Dictate AnywhereTests/OverlayScreenPickerTests.swift
+++ b/Dictate AnywhereTests/OverlayScreenPickerTests.swift
@@ -15,6 +15,34 @@ final class OverlayScreenPickerTests: XCTestCase {
     private var pointOnPrimary: CGPoint { CGPoint(x: 960, y: 540) }
     private var pointOnSecondary: CGPoint { CGPoint(x: -720, y: 450) }
 
+    // MARK: - A layout measured in the field
+
+    /// The desktop this bug was actually reproduced on: a 1512x982 built-in
+    /// display as primary, with a 2560x1440 ultrawide to its right whose
+    /// greater height puts its origin below the primary's. The accessibility
+    /// point is the real focused-window position VS Code reported while a text
+    /// box on the ultrawide had focus.
+    func testChoosesTheUltrawideForAWindowMeasuredOnIt() {
+        let builtIn = CGRect(x: 0, y: 0, width: 1512, height: 982)
+        let ultrawide = CGRect(x: 1512, y: -458, width: 2560, height: 1440)
+
+        let focusPoint = OverlayScreenPicker.appKitPoint(
+            fromAccessibilityPoint: CGPoint(x: 1512, y: 30),
+            primaryFrame: builtIn
+        )
+
+        XCTAssertEqual(focusPoint, CGPoint(x: 1512, y: 952))
+        XCTAssertEqual(
+            OverlayScreenPicker.pickScreenIndex(
+                screenFrames: [builtIn, ultrawide],
+                focusPoint: focusPoint,
+                mouseLocation: CGPoint(x: 466, y: 475)
+            ),
+            1,
+            "the overlay must follow the focused window, not the pointer on the built-in display"
+        )
+    }
+
     // MARK: - Screen selection
 
     func testPicksScreenContainingFocusedTextField() {

--- a/Dictate AnywhereTests/OverlayScreenSessionTests.swift
+++ b/Dictate AnywhereTests/OverlayScreenSessionTests.swift
@@ -1,53 +1,50 @@
 import XCTest
 @testable import Dictate_Anywhere_Dev
 
-/// Choosing the overlay's display is expensive: it reaches across a process
-/// boundary to ask the focused application where it is. The overlay redraws on
-/// every state update, so that choice has to be made once per visible session
-/// and reused, not repeated per frame.
-///
-/// The layout is a two-display desktop: the primary 1920x1080 display at the
-/// origin and a 1440x900 secondary to its left, which gives the secondary the
-/// negative x origin a real left-hand monitor has.
+/// Choosing the overlay's display is expensive: it crosses a process boundary
+/// to ask the target application where it is. The overlay repositions on every
+/// update, so that choice is made once per dictation and reused — but it has to
+/// be reused safely, which means surviving display reconfiguration and never
+/// outliving the dictation it belongs to.
 final class OverlayScreenSessionTests: XCTestCase {
-    private let primaryVisibleFrame = CGRect(x: 0, y: 0, width: 1920, height: 1055)
-    private let secondaryVisibleFrame = CGRect(x: -1440, y: 0, width: 1440, height: 875)
+    private let builtIn = OverlayDisplay(id: 1, visibleFrame: CGRect(x: 0, y: 0, width: 1512, height: 955))
+    private let middle = OverlayDisplay(id: 2, visibleFrame: CGRect(x: 1512, y: -458, width: 2560, height: 1410))
+    private let right = OverlayDisplay(id: 3, visibleFrame: CGRect(x: 4072, y: 0, width: 1920, height: 1055))
 
     /// Stands in for the window server and the accessibility API.
     private final class SpyResolver: OverlayScreenResolving {
-        var frames: [CGRect]
-        var indexToResolve: Int?
+        var displayList: [OverlayDisplay]
+        var displayIDToResolve: CGDirectDisplayID?
         private(set) var resolveCount = 0
-        private(set) var visibleFramesCount = 0
+        private(set) var requestedTargets: [pid_t?] = []
 
-        init(frames: [CGRect], indexToResolve: Int?) {
-            self.frames = frames
-            self.indexToResolve = indexToResolve
+        init(displayList: [OverlayDisplay], displayIDToResolve: CGDirectDisplayID?) {
+            self.displayList = displayList
+            self.displayIDToResolve = displayIDToResolve
         }
 
-        func visibleFrames() -> [CGRect] {
-            visibleFramesCount += 1
-            return frames
+        func displays() -> [OverlayDisplay] {
+            displayList
         }
 
-        func resolveScreenIndex() -> Int? {
+        func resolveDisplayID(forApplication processIdentifier: pid_t?) -> CGDirectDisplayID? {
             resolveCount += 1
-            return indexToResolve
+            requestedTargets.append(processIdentifier)
+            return displayIDToResolve
         }
     }
 
-    private func makeResolver(indexToResolve: Int? = 1) -> SpyResolver {
-        SpyResolver(
-            frames: [primaryVisibleFrame, secondaryVisibleFrame],
-            indexToResolve: indexToResolve
-        )
+    private func makeResolver(
+        displays: [OverlayDisplay]? = nil,
+        resolving displayID: CGDirectDisplayID? = 2
+    ) -> SpyResolver {
+        SpyResolver(displayList: displays ?? [builtIn, middle, right], displayIDToResolve: displayID)
     }
 
     // MARK: - One lookup per session
 
-    /// The listening waveform updates about thirty times a second. Every one of
-    /// those updates repositions the overlay, and none of them may pay for a
-    /// fresh cross-process lookup.
+    /// The listening waveform updates about thirty times a second, and none of
+    /// those updates may pay for a fresh cross-process lookup.
     func testResolvesTheDisplayOnceAcrossRepeatedUpdates() {
         let resolver = makeResolver()
         let session = OverlayScreenSession(resolver: resolver)
@@ -59,99 +56,176 @@ final class OverlayScreenSessionTests: XCTestCase {
         XCTAssertEqual(resolver.resolveCount, 1)
     }
 
-    func testReturnsTheVisibleFrameOfTheResolvedDisplay() {
-        let session = OverlayScreenSession(resolver: makeResolver(indexToResolve: 1))
+    func testReturnsTheVisibleFrameOfTheChosenDisplay() {
+        let session = OverlayScreenSession(resolver: makeResolver(resolving: middle.id))
 
-        XCTAssertEqual(session.visibleFrame(), secondaryVisibleFrame)
+        XCTAssertEqual(session.visibleFrame(), middle.visibleFrame)
     }
 
-    /// Re-resolving mid-session would let the overlay hop displays in the
+    /// Re-choosing mid-dictation would let the overlay hop displays in the
     /// middle of a sentence just because the pointer wandered.
     func testKeepsTheFirstDisplayEvenWhenTheResolverWouldNowChooseAnother() {
-        let resolver = makeResolver(indexToResolve: 1)
+        let resolver = makeResolver(resolving: middle.id)
         let session = OverlayScreenSession(resolver: resolver)
+        XCTAssertEqual(session.visibleFrame(), middle.visibleFrame)
 
-        XCTAssertEqual(session.visibleFrame(), secondaryVisibleFrame)
-        resolver.indexToResolve = 0
+        resolver.displayIDToResolve = builtIn.id
 
-        XCTAssertEqual(session.visibleFrame(), secondaryVisibleFrame)
+        XCTAssertEqual(session.visibleFrame(), middle.visibleFrame)
         XCTAssertEqual(resolver.resolveCount, 1)
     }
 
-    // MARK: - A new session picks again
-
-    func testEndingTheSessionResolvesTheDisplayAgain() {
-        let resolver = makeResolver(indexToResolve: 1)
+    func testRereadsDisplayGeometryOnEveryUpdate() {
+        let resolver = makeResolver(resolving: middle.id)
         let session = OverlayScreenSession(resolver: resolver)
-        XCTAssertEqual(session.visibleFrame(), secondaryVisibleFrame)
+
+        XCTAssertEqual(session.visibleFrame(), middle.visibleFrame)
+
+        let grown = OverlayDisplay(id: middle.id, visibleFrame: CGRect(x: 1512, y: -458, width: 2560, height: 1440))
+        resolver.displayList = [builtIn, grown, right]
+
+        XCTAssertEqual(session.visibleFrame(), grown.visibleFrame)
+    }
+
+    // MARK: - Session boundaries
+
+    func testEndingTheSessionChoosesADisplayAgain() {
+        let resolver = makeResolver(resolving: middle.id)
+        let session = OverlayScreenSession(resolver: resolver)
+        XCTAssertEqual(session.visibleFrame(), middle.visibleFrame)
 
         session.end()
-        resolver.indexToResolve = 0
+        resolver.displayIDToResolve = builtIn.id
 
-        XCTAssertEqual(session.visibleFrame(), primaryVisibleFrame)
+        XCTAssertEqual(session.visibleFrame(), builtIn.visibleFrame)
         XCTAssertEqual(resolver.resolveCount, 2)
     }
 
-    // MARK: - Displays changing underneath a live session
-
-    /// Reusing a display index means it can go stale. Unplugging the chosen
-    /// monitor mid-dictation must not leave the overlay stranded off-screen.
-    func testResolvesAgainWhenTheChosenDisplayIsUnplugged() {
-        let resolver = makeResolver(indexToResolve: 1)
+    /// A new dictation must never inherit the previous dictation's display,
+    /// even when it begins before the previous overlay has finished hiding.
+    func testBeginningASessionChoosesADisplayAgain() {
+        let resolver = makeResolver(resolving: middle.id)
         let session = OverlayScreenSession(resolver: resolver)
-        XCTAssertEqual(session.visibleFrame(), secondaryVisibleFrame)
+        XCTAssertEqual(session.visibleFrame(), middle.visibleFrame)
 
-        resolver.frames = [primaryVisibleFrame]
-        resolver.indexToResolve = 0
+        session.begin(targetProcessIdentifier: nil)
+        resolver.displayIDToResolve = right.id
 
-        XCTAssertEqual(session.visibleFrame(), primaryVisibleFrame)
+        XCTAssertEqual(session.visibleFrame(), right.visibleFrame)
         XCTAssertEqual(resolver.resolveCount, 2)
     }
 
-    /// Display geometry is cheap to read and does change while the overlay is
-    /// up — the dock hides, the menu bar reveals — so it is re-read per update
-    /// even though the display choice is not.
-    func testRereadsDisplayGeometryOnEveryUpdate() {
+    // MARK: - Following the app the text will land in
+
+    func testAsksAboutTheSessionsTargetApplication() {
+        let resolver = makeResolver()
+        let session = OverlayScreenSession(resolver: resolver)
+
+        session.begin(targetProcessIdentifier: 4242)
+        _ = session.visibleFrame()
+
+        XCTAssertEqual(resolver.requestedTargets, [4242])
+    }
+
+    /// The target is captured before audio startup and the transcript is pasted
+    /// into it afterwards, so the overlay must follow that app even if the user
+    /// brings a different one forward while the microphone is starting.
+    func testKeepsTheCapturedTargetAcrossAFrontmostAppChange() {
+        let resolver = makeResolver()
+        let session = OverlayScreenSession(resolver: resolver)
+        session.begin(targetProcessIdentifier: 4242)
+
+        _ = session.visibleFrame()
+        session.end()
+        session.begin(targetProcessIdentifier: 4242)
+        _ = session.visibleFrame()
+
+        XCTAssertEqual(resolver.requestedTargets, [4242, 4242])
+    }
+
+    func testAsksAboutTheFrontmostApplicationWhenNoTargetWasCaptured() {
         let resolver = makeResolver()
         let session = OverlayScreenSession(resolver: resolver)
 
         _ = session.visibleFrame()
-        _ = session.visibleFrame()
-        _ = session.visibleFrame()
 
-        XCTAssertEqual(resolver.visibleFramesCount, 3)
+        XCTAssertEqual(resolver.requestedTargets, [nil])
+    }
+
+    // MARK: - Displays changing underneath a live session
+
+    /// Identity has to be the physical display, not its position in the list.
+    /// Removing a display ahead of the chosen one shifts every later index, so
+    /// an index-based cache would silently point at a different monitor.
+    func testKeepsTheSamePhysicalDisplayWhenAnEarlierDisplayIsUnplugged() {
+        let resolver = makeResolver(resolving: right.id)
+        let session = OverlayScreenSession(resolver: resolver)
+        XCTAssertEqual(session.visibleFrame(), right.visibleFrame)
+
+        resolver.displayList = [builtIn, right]
+        resolver.displayIDToResolve = builtIn.id
+
+        XCTAssertEqual(session.visibleFrame(), right.visibleFrame, "the overlay must stay on the display it chose")
+        XCTAssertEqual(resolver.resolveCount, 1, "a surviving display needs no fresh lookup")
+    }
+
+    /// The reordering has to move the chosen display to a different position,
+    /// or an index-based cache would keep passing by coincidence.
+    func testKeepsTheSamePhysicalDisplayWhenTheDisplayOrderChanges() {
+        let resolver = makeResolver(resolving: middle.id)
+        let session = OverlayScreenSession(resolver: resolver)
+        XCTAssertEqual(session.visibleFrame(), middle.visibleFrame)
+
+        // `middle` moves from index 1 to index 0; index 1 now holds `builtIn`.
+        resolver.displayList = [middle, builtIn, right]
+
+        XCTAssertEqual(session.visibleFrame(), middle.visibleFrame)
+        XCTAssertEqual(resolver.resolveCount, 1)
+    }
+
+    /// The chosen display going away mid-dictation is the one case that does
+    /// need a fresh lookup, or the overlay would be stranded off-screen.
+    func testChoosesAgainWhenTheChosenDisplayIsUnplugged() {
+        let resolver = makeResolver(resolving: middle.id)
+        let session = OverlayScreenSession(resolver: resolver)
+        XCTAssertEqual(session.visibleFrame(), middle.visibleFrame)
+
+        resolver.displayList = [builtIn, right]
+        resolver.displayIDToResolve = right.id
+
+        XCTAssertEqual(session.visibleFrame(), right.visibleFrame)
+        XCTAssertEqual(resolver.resolveCount, 2)
     }
 
     // MARK: - Nothing to place the overlay on
 
     func testReturnsNilWhenThereAreNoDisplays() {
-        let resolver = SpyResolver(frames: [], indexToResolve: 0)
-        let session = OverlayScreenSession(resolver: resolver)
+        let session = OverlayScreenSession(resolver: makeResolver(displays: [], resolving: 1))
 
         XCTAssertNil(session.visibleFrame())
     }
 
     func testReturnsNilWhenNoDisplayCanBeChosen() {
-        let session = OverlayScreenSession(resolver: makeResolver(indexToResolve: nil))
+        let session = OverlayScreenSession(resolver: makeResolver(resolving: nil))
+
+        XCTAssertNil(session.visibleFrame())
+    }
+
+    func testReturnsNilWhenTheChosenDisplayIsNotAttached() {
+        let session = OverlayScreenSession(resolver: makeResolver(resolving: 99))
 
         XCTAssertNil(session.visibleFrame())
     }
 
     /// A failed choice must not be cached as if it were a decision, or the
-    /// overlay would stay unplaced for the rest of the session.
+    /// overlay would stay unplaced for the rest of the dictation.
     func testRetriesAfterAFailedChoice() {
-        let resolver = makeResolver(indexToResolve: nil)
+        let resolver = makeResolver(resolving: nil)
         let session = OverlayScreenSession(resolver: resolver)
         XCTAssertNil(session.visibleFrame())
 
-        resolver.indexToResolve = 1
+        resolver.displayIDToResolve = middle.id
 
-        XCTAssertEqual(session.visibleFrame(), secondaryVisibleFrame)
-    }
-
-    func testReturnsNilWhenTheChosenIndexIsOutOfRange() {
-        let session = OverlayScreenSession(resolver: makeResolver(indexToResolve: 5))
-
-        XCTAssertNil(session.visibleFrame())
+        XCTAssertEqual(session.visibleFrame(), middle.visibleFrame)
     }
 }

--- a/Dictate AnywhereTests/OverlayScreenSessionTests.swift
+++ b/Dictate AnywhereTests/OverlayScreenSessionTests.swift
@@ -1,0 +1,157 @@
+import XCTest
+@testable import Dictate_Anywhere_Dev
+
+/// Choosing the overlay's display is expensive: it reaches across a process
+/// boundary to ask the focused application where it is. The overlay redraws on
+/// every state update, so that choice has to be made once per visible session
+/// and reused, not repeated per frame.
+///
+/// The layout is a two-display desktop: the primary 1920x1080 display at the
+/// origin and a 1440x900 secondary to its left, which gives the secondary the
+/// negative x origin a real left-hand monitor has.
+final class OverlayScreenSessionTests: XCTestCase {
+    private let primaryVisibleFrame = CGRect(x: 0, y: 0, width: 1920, height: 1055)
+    private let secondaryVisibleFrame = CGRect(x: -1440, y: 0, width: 1440, height: 875)
+
+    /// Stands in for the window server and the accessibility API.
+    private final class SpyResolver: OverlayScreenResolving {
+        var frames: [CGRect]
+        var indexToResolve: Int?
+        private(set) var resolveCount = 0
+        private(set) var visibleFramesCount = 0
+
+        init(frames: [CGRect], indexToResolve: Int?) {
+            self.frames = frames
+            self.indexToResolve = indexToResolve
+        }
+
+        func visibleFrames() -> [CGRect] {
+            visibleFramesCount += 1
+            return frames
+        }
+
+        func resolveScreenIndex() -> Int? {
+            resolveCount += 1
+            return indexToResolve
+        }
+    }
+
+    private func makeResolver(indexToResolve: Int? = 1) -> SpyResolver {
+        SpyResolver(
+            frames: [primaryVisibleFrame, secondaryVisibleFrame],
+            indexToResolve: indexToResolve
+        )
+    }
+
+    // MARK: - One lookup per session
+
+    /// The listening waveform updates about thirty times a second. Every one of
+    /// those updates repositions the overlay, and none of them may pay for a
+    /// fresh cross-process lookup.
+    func testResolvesTheDisplayOnceAcrossRepeatedUpdates() {
+        let resolver = makeResolver()
+        let session = OverlayScreenSession(resolver: resolver)
+
+        for _ in 0..<30 {
+            _ = session.visibleFrame()
+        }
+
+        XCTAssertEqual(resolver.resolveCount, 1)
+    }
+
+    func testReturnsTheVisibleFrameOfTheResolvedDisplay() {
+        let session = OverlayScreenSession(resolver: makeResolver(indexToResolve: 1))
+
+        XCTAssertEqual(session.visibleFrame(), secondaryVisibleFrame)
+    }
+
+    /// Re-resolving mid-session would let the overlay hop displays in the
+    /// middle of a sentence just because the pointer wandered.
+    func testKeepsTheFirstDisplayEvenWhenTheResolverWouldNowChooseAnother() {
+        let resolver = makeResolver(indexToResolve: 1)
+        let session = OverlayScreenSession(resolver: resolver)
+
+        XCTAssertEqual(session.visibleFrame(), secondaryVisibleFrame)
+        resolver.indexToResolve = 0
+
+        XCTAssertEqual(session.visibleFrame(), secondaryVisibleFrame)
+        XCTAssertEqual(resolver.resolveCount, 1)
+    }
+
+    // MARK: - A new session picks again
+
+    func testEndingTheSessionResolvesTheDisplayAgain() {
+        let resolver = makeResolver(indexToResolve: 1)
+        let session = OverlayScreenSession(resolver: resolver)
+        XCTAssertEqual(session.visibleFrame(), secondaryVisibleFrame)
+
+        session.end()
+        resolver.indexToResolve = 0
+
+        XCTAssertEqual(session.visibleFrame(), primaryVisibleFrame)
+        XCTAssertEqual(resolver.resolveCount, 2)
+    }
+
+    // MARK: - Displays changing underneath a live session
+
+    /// Reusing a display index means it can go stale. Unplugging the chosen
+    /// monitor mid-dictation must not leave the overlay stranded off-screen.
+    func testResolvesAgainWhenTheChosenDisplayIsUnplugged() {
+        let resolver = makeResolver(indexToResolve: 1)
+        let session = OverlayScreenSession(resolver: resolver)
+        XCTAssertEqual(session.visibleFrame(), secondaryVisibleFrame)
+
+        resolver.frames = [primaryVisibleFrame]
+        resolver.indexToResolve = 0
+
+        XCTAssertEqual(session.visibleFrame(), primaryVisibleFrame)
+        XCTAssertEqual(resolver.resolveCount, 2)
+    }
+
+    /// Display geometry is cheap to read and does change while the overlay is
+    /// up — the dock hides, the menu bar reveals — so it is re-read per update
+    /// even though the display choice is not.
+    func testRereadsDisplayGeometryOnEveryUpdate() {
+        let resolver = makeResolver()
+        let session = OverlayScreenSession(resolver: resolver)
+
+        _ = session.visibleFrame()
+        _ = session.visibleFrame()
+        _ = session.visibleFrame()
+
+        XCTAssertEqual(resolver.visibleFramesCount, 3)
+    }
+
+    // MARK: - Nothing to place the overlay on
+
+    func testReturnsNilWhenThereAreNoDisplays() {
+        let resolver = SpyResolver(frames: [], indexToResolve: 0)
+        let session = OverlayScreenSession(resolver: resolver)
+
+        XCTAssertNil(session.visibleFrame())
+    }
+
+    func testReturnsNilWhenNoDisplayCanBeChosen() {
+        let session = OverlayScreenSession(resolver: makeResolver(indexToResolve: nil))
+
+        XCTAssertNil(session.visibleFrame())
+    }
+
+    /// A failed choice must not be cached as if it were a decision, or the
+    /// overlay would stay unplaced for the rest of the session.
+    func testRetriesAfterAFailedChoice() {
+        let resolver = makeResolver(indexToResolve: nil)
+        let session = OverlayScreenSession(resolver: resolver)
+        XCTAssertNil(session.visibleFrame())
+
+        resolver.indexToResolve = 1
+
+        XCTAssertEqual(session.visibleFrame(), secondaryVisibleFrame)
+    }
+
+    func testReturnsNilWhenTheChosenIndexIsOutOfRange() {
+        let session = OverlayScreenSession(resolver: makeResolver(indexToResolve: 5))
+
+        XCTAssertNil(session.visibleFrame())
+    }
+}

--- a/Dictate AnywhereTests/OverlayWindowScreenSessionTests.swift
+++ b/Dictate AnywhereTests/OverlayWindowScreenSessionTests.swift
@@ -101,6 +101,36 @@ final class OverlayWindowScreenSessionTests: XCTestCase {
         XCTAssertEqual(resolver.resolveCount, 2)
     }
 
+    // MARK: - Not leaving the previous dictation on screen
+
+    /// A finished dictation leaves its badge up for a second while the app goes
+    /// straight back to idle, so the next dictation routinely starts before the
+    /// hide fires. Cancelling that hide without dismissing anything would leave
+    /// the previous badge on the previous monitor for the whole of the next
+    /// dictation's startup — longer than if the hide had simply been left alone.
+    func testBeginningASessionDismissesThePreviousDictationsOverlay() {
+        showListening(updates: 3)
+        overlay.show(state: .success)
+        overlay.hide(afterDelay: 5.0)
+        XCTAssertTrue(overlay.isVisible, "precondition: the success badge is still up")
+
+        overlay.beginSession(targetProcessIdentifier: 4242)
+
+        XCTAssertFalse(overlay.isVisible, "the previous badge must not survive into the next dictation's startup")
+    }
+
+    /// The pending hide is what would otherwise reset the screen session, so
+    /// dismissing the old overlay must not take the new target with it.
+    func testDismissingThePreviousOverlayKeepsTheNewSessionsTarget() {
+        showListening(updates: 3)
+        overlay.hide(afterDelay: 5.0)
+
+        overlay.beginSession(targetProcessIdentifier: 4242)
+        showListening(updates: 3)
+
+        XCTAssertEqual(resolver.requestedTargets, [nil, 4242])
+    }
+
     // MARK: - Following the app the text will land in
 
     /// The insertion target is captured before audio startup; the overlay must

--- a/Dictate AnywhereTests/OverlayWindowScreenSessionTests.swift
+++ b/Dictate AnywhereTests/OverlayWindowScreenSessionTests.swift
@@ -1,0 +1,85 @@
+import XCTest
+@testable import Dictate_Anywhere_Dev
+
+/// `OverlayWindow.show` runs on every overlay update, and `AppState` drives the
+/// listening waveform at roughly thirty updates a second. These tests pin the
+/// wiring between that redraw loop and the display lookup: one lookup while the
+/// overlay stays up, a fresh one after it hides.
+@MainActor
+final class OverlayWindowScreenSessionTests: XCTestCase {
+
+    /// Stands in for the window server and the accessibility API.
+    private final class SpyResolver: OverlayScreenResolving {
+        var indexToResolve: Int? = 1
+        private(set) var resolveCount = 0
+
+        func visibleFrames() -> [CGRect] {
+            [
+                CGRect(x: 0, y: 0, width: 1920, height: 1055),
+                CGRect(x: -1440, y: 0, width: 1440, height: 875),
+            ]
+        }
+
+        func resolveScreenIndex() -> Int? {
+            resolveCount += 1
+            return indexToResolve
+        }
+    }
+
+    private var resolver: SpyResolver!
+    private var overlay: OverlayWindow!
+
+    override func setUp() {
+        super.setUp()
+        resolver = SpyResolver()
+        overlay = OverlayWindow(screenResolver: resolver)
+    }
+
+    override func tearDown() {
+        overlay.hide(afterDelay: 0)
+        overlay = nil
+        resolver = nil
+        super.tearDown()
+    }
+
+    private func showListening(updates: Int) {
+        for update in 0..<updates {
+            overlay.show(state: .listening(level: Float(update % 10) / 10, transcript: ""))
+        }
+    }
+
+    func testRepeatedListeningUpdatesResolveTheDisplayOnce() {
+        showListening(updates: 30)
+
+        XCTAssertEqual(resolver.resolveCount, 1)
+    }
+
+    /// One dictation walks through several states without hiding in between;
+    /// the overlay must not re-pick its display partway through.
+    func testStateChangesWithinOneSessionKeepTheSameDisplay() {
+        overlay.show(state: .listening(level: 0.2, transcript: "hello"))
+        overlay.show(state: .processing)
+        overlay.show(state: .success)
+
+        XCTAssertEqual(resolver.resolveCount, 1)
+    }
+
+    func testHidingTheOverlayStartsANewSession() {
+        showListening(updates: 5)
+        overlay.hide(afterDelay: 0)
+
+        showListening(updates: 5)
+
+        XCTAssertEqual(resolver.resolveCount, 2)
+    }
+
+    func testEachDictationResolvesTheDisplayExactlyOnce() {
+        for _ in 0..<3 {
+            showListening(updates: 10)
+            overlay.show(state: .processing)
+            overlay.hide(afterDelay: 0)
+        }
+
+        XCTAssertEqual(resolver.resolveCount, 3)
+    }
+}

--- a/Dictate AnywhereTests/OverlayWindowScreenSessionTests.swift
+++ b/Dictate AnywhereTests/OverlayWindowScreenSessionTests.swift
@@ -3,26 +3,29 @@ import XCTest
 
 /// `OverlayWindow.show` runs on every overlay update, and `AppState` drives the
 /// listening waveform at roughly thirty updates a second. These tests pin the
-/// wiring between that redraw loop and the display lookup: one lookup while the
-/// overlay stays up, a fresh one after it hides.
+/// wiring between that redraw loop and the display lookup: one lookup while a
+/// dictation is up, and a fresh one for the next dictation — including when the
+/// next one starts before the previous overlay has finished hiding.
 @MainActor
 final class OverlayWindowScreenSessionTests: XCTestCase {
 
     /// Stands in for the window server and the accessibility API.
     private final class SpyResolver: OverlayScreenResolving {
-        var indexToResolve: Int? = 1
+        var displayIDToResolve: CGDirectDisplayID? = 2
         private(set) var resolveCount = 0
+        private(set) var requestedTargets: [pid_t?] = []
 
-        func visibleFrames() -> [CGRect] {
+        func displays() -> [OverlayDisplay] {
             [
-                CGRect(x: 0, y: 0, width: 1920, height: 1055),
-                CGRect(x: -1440, y: 0, width: 1440, height: 875),
+                OverlayDisplay(id: 1, visibleFrame: CGRect(x: 0, y: 0, width: 1512, height: 955)),
+                OverlayDisplay(id: 2, visibleFrame: CGRect(x: 1512, y: -458, width: 2560, height: 1410)),
             ]
         }
 
-        func resolveScreenIndex() -> Int? {
+        func resolveDisplayID(forApplication processIdentifier: pid_t?) -> CGDirectDisplayID? {
             resolveCount += 1
-            return indexToResolve
+            requestedTargets.append(processIdentifier)
+            return displayIDToResolve
         }
     }
 
@@ -71,6 +74,50 @@ final class OverlayWindowScreenSessionTests: XCTestCase {
         showListening(updates: 5)
 
         XCTAssertEqual(resolver.resolveCount, 2)
+    }
+
+    /// A finished dictation schedules a delayed hide and immediately goes idle.
+    /// Starting another dictation inside that delay cancels the hide, so the
+    /// display choice has to be reset by the new dictation rather than relying
+    /// on the hide that never fired.
+    func testASessionStartedBeforeTheDelayedHideFiresChoosesADisplayAgain() {
+        showListening(updates: 5)
+        overlay.hide(afterDelay: 5.0)
+        XCTAssertEqual(resolver.resolveCount, 1)
+
+        resolver.displayIDToResolve = 1
+        showListening(updates: 5)
+
+        XCTAssertEqual(resolver.resolveCount, 2, "the interrupted hide must not carry its display into the new dictation")
+    }
+
+    func testBeginningASessionBeforeTheDelayedHideFiresChoosesADisplayAgain() {
+        showListening(updates: 5)
+        overlay.hide(afterDelay: 5.0)
+
+        overlay.beginSession(targetProcessIdentifier: 4242)
+        showListening(updates: 5)
+
+        XCTAssertEqual(resolver.resolveCount, 2)
+    }
+
+    // MARK: - Following the app the text will land in
+
+    /// The insertion target is captured before audio startup; the overlay must
+    /// ask about that app, not whichever app is frontmost by the time the
+    /// microphone is live and the overlay finally appears.
+    func testResolvesAgainstTheCapturedInsertionTarget() {
+        overlay.beginSession(targetProcessIdentifier: 4242)
+
+        showListening(updates: 5)
+
+        XCTAssertEqual(resolver.requestedTargets, [4242])
+    }
+
+    func testFallsBackToTheFrontmostApplicationWithoutACapturedTarget() {
+        showListening(updates: 5)
+
+        XCTAssertEqual(resolver.requestedTargets, [nil])
     }
 
     func testEachDictationResolvesTheDisplayExactlyOnce() {


### PR DESCRIPTION
## The bug

On a multi-monitor desktop the dictation overlay appears on the wrong display: you type in an app on your external monitor, hit the hotkey, and the pill shows up at the bottom of the built-in display instead.

`OverlayWindow.positionWindow()` chose its display with `NSScreen.main`, which AppKit's SDK header defines as *"Screen with key window"* — meaning **our** key window. This app ships `LSUIElement` and runs with an `.accessory` activation policy, and the overlay itself is borderless, `ignoresMouseEvents`, and shown via `orderFrontRegardless()`, so it never becomes key. During dictation the app has no key window at all and AppKit falls back to the primary display — a choice unrelated to where the user is typing.

The placement arithmetic was never wrong: `visibleFrame` is already in global coordinates, so centering works on any display. Only the screen *selection* was broken.

## The fix

Follow the frontmost application — the same app `TextInserter` pastes into — and ask it, in order:

1. its focused UI element's position;
2. that element's containing window;
3. the application's focused window;
4. failing all of those, the pointer's display;
5. failing that, the primary display.


### Two things this deliberately does *not* do

**It never uses the system-wide element's `kAXFocusedUIElement`.** That is the obvious way to find the focused control and it is not reliable: on a real two-display desktop it was observed returning a stale element belonging to a *different process* than the frontmost app. Because dictation inserts into the frontmost app, every query is scoped to that app's PID instead.

**It does not rely on a focused element existing.** Chromium- and Gecko-based apps — VS Code, Slack, Firefox, Electron apps generally — keep their accessibility tree switched off until they detect a screen reader, so `kAXFocusedUIElement` answers `kAXErrorNoValue` for them however it is asked. Their windows remain ordinary windows visible to accessibility, and a window is enough to choose a display, so the focused-window step carries these apps.

### Other issues fixed along the way

- The old `guard let screen = NSScreen.main` silently returned when `NSScreen.main` was nil (which happens transiently around display sleep and reconfiguration), leaving the window at a stale frame — (0,0), the bottom-left of the primary display, for a window never positioned. The fallback chain now always resolves to a display when one exists.
- The display is resolved **once per visible overlay session** rather than per update. `showImpl()` runs on every state change and the listening waveform updates roughly thirty times a second, so resolving each time would put synchronous cross-process accessibility calls on the main thread at that rate, and would let the overlay hop displays mid-sentence if the pointer wandered. A cached display that disappears (monitor unplugged mid-dictation) is re-resolved rather than left stranding the overlay off-screen.
- The accessibility messaging timeout is applied through a scope that restores it on **every** exit path, including a throw. Setting it on the system-wide element applies it globally to the process, so leaving it in place would silently shorten unrelated reads — `TextInserter`'s among them, which talk to apps that are legitimately slow.

## Structure

- `OverlayScreenPicker` — display selection and coordinate math, plain `CGRect`/`CGPoint` and no AppKit types, so multi-display behavior is testable against synthetic layouts without attaching monitors.
- `OverlayScreenSession` — holds the chosen display for one visible session, behind an injectable resolver.
- `OverlayScreenResolver` — the accessibility boundary, kept deliberately thin.
- `AccessibilityMessagingTimeout` — the scoped-timeout helper.

`OverlayWindow` keeps window lifecycle only, and is 62 lines lighter for it.

## Testing

30 new tests; full suite green at **246 tests, 0 failures** (8 pre-existing skips are Mandarin/benchmark fixture tests).

- `OverlayScreenPickerTests` (11) — a two-display layout with a left-hand monitor at a negative x origin: focus beats the pointer, the pointer covers focus being unavailable or off-screen, the primary display is the last resort, the accessibility flip including a display above the primary, and bottom-centered placement on a negatively-positioned display. One test encodes a layout measured in the field — a 2560x1440 ultrawide right of a 1512x982 built-in, using the real window position reported while a text box on the ultrawide held focus.
- `OverlayScreenSessionTests` (10) — one lookup across repeated updates, a new session re-choosing, keeping the first display when the resolver would now choose another, re-resolving when the chosen display is unplugged, and re-reading display geometry every update.
- `OverlayWindowScreenSessionTests` (4) — the wiring: 30 listening updates cost one lookup, state changes within a session keep their display, hiding starts a new session.
- `AccessibilityMessagingTimeoutTests` (5) — the timeout is restored after success, after a throw, and after a lookup that comes back empty.

**Verified on hardware.** .

