### PR TITLE
Add per-app prompt profiles for transcript cleanup

### DIFF
--- a/Dictate Anywhere/AIPostProcessingView.swift
+++ b/Dictate Anywhere/AIPostProcessingView.swift
@@ -102,6 +102,11 @@ struct AIPostProcessingView: View {
             case .openAICompatible:
                 openAICompatibleContent(settings: settings)
             }
+
+            if settings.transcriptPostProcessingMode != .none,
+               settings.transcriptPostProcessingMode != .fluidAudioVocabulary {
+                AppPromptSettingsSection()
+            }
         }
         .task(id: providerTaskID(settings: settings)) {
             guard shouldAutoRefreshProviderAvailability else { return }

--- a/Dictate Anywhere/AppPromptResolver.swift
+++ b/Dictate Anywhere/AppPromptResolver.swift
@@ -17,7 +17,8 @@ enum AppPromptResolver {
         fallback: String
     ) -> String {
         guard enabled, let bundleIdentifier,
-              let match = mappings.first(where: { $0.bundleIdentifier == bundleIdentifier })
+              let match = mappings.first(where: { $0.bundleIdentifier == bundleIdentifier }),
+              !match.prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         else { return fallback }
         return match.prompt
     }

--- a/Dictate Anywhere/AppPromptResolver.swift
+++ b/Dictate Anywhere/AppPromptResolver.swift
@@ -1,0 +1,24 @@
+//
+//  AppPromptResolver.swift
+//  Dictate Anywhere
+//
+//  Pure decision logic for per-app cleanup prompts: given the frontmost
+//  app's bundle identifier, picks the matching rule's prompt or falls back
+//  to the active provider's global prompt.
+//
+
+import Foundation
+
+enum AppPromptResolver {
+    static func resolve(
+        bundleIdentifier: String?,
+        mappings: [AppPromptMapping],
+        enabled: Bool,
+        fallback: String
+    ) -> String {
+        guard enabled, let bundleIdentifier,
+              let match = mappings.first(where: { $0.bundleIdentifier == bundleIdentifier })
+        else { return fallback }
+        return match.prompt
+    }
+}

--- a/Dictate Anywhere/AppPromptSettingsSection.swift
+++ b/Dictate Anywhere/AppPromptSettingsSection.swift
@@ -16,6 +16,7 @@ struct AppPromptSettingsSection: View {
 
     var body: some View {
         @Bindable var settings = appState.settings
+        let runningApps = Self.runningApps()
 
         VStack(alignment: .leading, spacing: DS.Spacing.section) {
             DSSection(overline: "App Prompts") {
@@ -29,7 +30,7 @@ struct AppPromptSettingsSection: View {
                         DSDivider()
                         AppPromptMappingRow(
                             mapping: mapping,
-                            runningApps: Self.runningApps(),
+                            runningApps: runningApps,
                             takenBundleIdentifiers: Set(
                                 settings.appPromptMappings
                                     .filter { $0.id != mapping.id }
@@ -40,21 +41,21 @@ struct AppPromptSettingsSection: View {
                 }
             }
 
-            if settings.appPromptMappingEnabled, canAddMapping {
-                DSAddButton(title: "Add App") { addMapping() }
+            if settings.appPromptMappingEnabled, canAddMapping(runningApps: runningApps) {
+                DSAddButton(title: "Add App") { addMapping(runningApps: runningApps) }
             }
         }
     }
 
-    private var canAddMapping: Bool {
+    private func canAddMapping(runningApps: [RunningAppInfo]) -> Bool {
         let taken = Set(appState.settings.appPromptMappings.map(\.bundleIdentifier))
-        return Self.runningApps().contains { !taken.contains($0.bundleIdentifier) }
+        return runningApps.contains { !taken.contains($0.bundleIdentifier) }
     }
 
-    private func addMapping() {
+    private func addMapping(runningApps: [RunningAppInfo]) {
         let settings = appState.settings
         let taken = Set(settings.appPromptMappings.map(\.bundleIdentifier))
-        guard let app = Self.runningApps().first(where: { !taken.contains($0.bundleIdentifier) }) else { return }
+        guard let app = runningApps.first(where: { !taken.contains($0.bundleIdentifier) }) else { return }
         settings.addAppPromptMapping(bundleIdentifier: app.bundleIdentifier, appName: app.localizedName)
     }
 
@@ -111,7 +112,6 @@ private struct AppPromptMappingRow: View {
                     placeholder: "Enter a prompt for this app…",
                     minHeight: 60
                 )
-                .labelsHidden()
             }
         }
     }

--- a/Dictate Anywhere/AppPromptSettingsSection.swift
+++ b/Dictate Anywhere/AppPromptSettingsSection.swift
@@ -1,0 +1,171 @@
+//
+//  AppPromptSettingsSection.swift
+//  Dictate Anywhere
+//
+//  "App Prompts" section of Transcript Cleanup settings: opt-in toggle plus
+//  per-app cleanup-prompt rows, matched against the frontmost app's bundle
+//  identifier at dictation time. One prompt per app, used by whichever
+//  post-processing provider is currently active.
+//
+
+import SwiftUI
+import AppKit
+
+struct AppPromptSettingsSection: View {
+    @Environment(AppState.self) private var appState
+
+    var body: some View {
+        @Bindable var settings = appState.settings
+
+        VStack(alignment: .leading, spacing: DS.Spacing.section) {
+            DSSection(overline: "App Prompts") {
+                DSStackedRow(
+                    label: "Use per-app prompts",
+                    caption: "When dictating into a matched app, use that app's prompt instead of the prompt above.",
+                    isOn: $settings.appPromptMappingEnabled
+                )
+                if settings.appPromptMappingEnabled {
+                    ForEach(settings.appPromptMappings) { mapping in
+                        DSDivider()
+                        AppPromptMappingRow(
+                            mapping: mapping,
+                            runningApps: Self.runningApps(),
+                            takenBundleIdentifiers: Set(
+                                settings.appPromptMappings
+                                    .filter { $0.id != mapping.id }
+                                    .map(\.bundleIdentifier)
+                            )
+                        )
+                    }
+                }
+            }
+
+            if settings.appPromptMappingEnabled, canAddMapping {
+                DSAddButton(title: "Add App") { addMapping() }
+            }
+        }
+    }
+
+    private var canAddMapping: Bool {
+        let taken = Set(appState.settings.appPromptMappings.map(\.bundleIdentifier))
+        return Self.runningApps().contains { !taken.contains($0.bundleIdentifier) }
+    }
+
+    private func addMapping() {
+        let settings = appState.settings
+        let taken = Set(settings.appPromptMappings.map(\.bundleIdentifier))
+        guard let app = Self.runningApps().first(where: { !taken.contains($0.bundleIdentifier) }) else { return }
+        settings.addAppPromptMapping(bundleIdentifier: app.bundleIdentifier, appName: app.localizedName)
+    }
+
+    /// Currently-running regular UI apps, excluding Dictate Anywhere itself.
+    /// Not unit-tested: `NSRunningApplication` has no public initializer, so
+    /// this thin OS-integration read is verified by the manual checklist,
+    /// same as the frontmost-app capture in `AppState.captureInsertionTargetApp()`.
+    static func runningApps() -> [RunningAppInfo] {
+        let selfBundleID = Bundle.main.bundleIdentifier
+        return NSWorkspace.shared.runningApplications
+            .filter { $0.activationPolicy == .regular }
+            .filter { $0.bundleIdentifier != nil && $0.bundleIdentifier != selfBundleID }
+            .map { RunningAppInfo(bundleIdentifier: $0.bundleIdentifier!, localizedName: $0.localizedName ?? $0.bundleIdentifier!) }
+            .sorted { $0.localizedName.localizedCaseInsensitiveCompare($1.localizedName) == .orderedAscending }
+    }
+}
+
+/// Lightweight, testable stand-in for the fields this feature needs off
+/// `NSRunningApplication`.
+struct RunningAppInfo: Identifiable, Hashable {
+    var id: String { bundleIdentifier }
+    let bundleIdentifier: String
+    let localizedName: String
+}
+
+// MARK: - Mapping Row
+
+private struct AppPromptMappingRow: View {
+    @Environment(AppState.self) private var appState
+    let mapping: AppPromptMapping
+    let runningApps: [RunningAppInfo]
+    let takenBundleIdentifiers: Set<String>
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            DSInfoRow(label: "App") {
+                HStack(spacing: 10) {
+                    DSDropdown(
+                        selection: bundleIdentifierBinding,
+                        options: bundleIdentifierOptions,
+                        title: { appName(for: $0) }
+                    )
+                    DSIconButton(
+                        systemImage: "trash",
+                        accessibilityLabel: "Delete app prompt"
+                    ) {
+                        appState.settings.removeAppPromptMapping(id: mapping.id)
+                    }
+                }
+            }
+            cardPadded {
+                SettingsMultilineTextArea(
+                    text: promptBinding,
+                    placeholder: "Enter a prompt for this app…",
+                    minHeight: 60
+                )
+                .labelsHidden()
+            }
+        }
+    }
+
+    /// The current app's bundle identifier plus every running,
+    /// not-already-mapped app — mirrors `InputSourceMappingRow.sourceOptions`.
+    private var bundleIdentifierOptions: [String] {
+        var ids = runningApps.map(\.bundleIdentifier).filter { !takenBundleIdentifiers.contains($0) }
+        if !ids.contains(mapping.bundleIdentifier) {
+            ids.insert(mapping.bundleIdentifier, at: 0)
+        }
+        return ids
+    }
+
+    private func appName(for bundleIdentifier: String) -> String {
+        if let app = runningApps.first(where: { $0.bundleIdentifier == bundleIdentifier }) {
+            return app.localizedName
+        }
+        // App no longer running; show the cached name.
+        return "\(mapping.appName) (not running)"
+    }
+
+    private var bundleIdentifierBinding: Binding<String> {
+        Binding(
+            get: { mapping.bundleIdentifier },
+            set: { newBundleIdentifier in
+                var updated = mapping
+                updated.bundleIdentifier = newBundleIdentifier
+                if let app = runningApps.first(where: { $0.bundleIdentifier == newBundleIdentifier }) {
+                    updated.appName = app.localizedName
+                }
+                appState.settings.updateAppPromptMapping(updated)
+            }
+        )
+    }
+
+    private var promptBinding: Binding<String> {
+        Binding(
+            get: { mapping.prompt },
+            set: { newPrompt in
+                var updated = mapping
+                updated.prompt = newPrompt
+                appState.settings.updateAppPromptMapping(updated)
+            }
+        )
+    }
+
+    @ViewBuilder
+    private func cardPadded<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            content()
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 12)
+        .padding(.horizontal, DS.Spacing.rowHorizontal)
+    }
+}

--- a/Dictate Anywhere/AppState.swift
+++ b/Dictate Anywhere/AppState.swift
@@ -712,13 +712,19 @@ final class AppState {
                 )
             }
         case .appleIntelligence:
-            if !settings.aiPostProcessingPrompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            let prompt = AppPromptResolver.resolve(
+                bundleIdentifier: insertionTargetApp?.bundleIdentifier,
+                mappings: settings.appPromptMappings,
+                enabled: settings.appPromptMappingEnabled,
+                fallback: settings.aiPostProcessingPrompt
+            )
+            if !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 if #available(macOS 26, *) {
                     if case .available = AIPostProcessingService.availability {
                         do {
                             processedText = try await AIPostProcessingService.process(
                                 text: finalText,
-                                prompt: settings.aiPostProcessingPrompt,
+                                prompt: prompt,
                                 vocabulary: settings.customVocabulary
                             )
                         } catch {
@@ -732,24 +738,36 @@ final class AppState {
                 logger.info("postProcessing: Apple Intelligence skipped because prompt is empty")
             }
         case .ollama:
+            let prompt = AppPromptResolver.resolve(
+                bundleIdentifier: insertionTargetApp?.bundleIdentifier,
+                mappings: settings.appPromptMappings,
+                enabled: settings.appPromptMappingEnabled,
+                fallback: settings.ollamaPostProcessingPrompt
+            )
             do {
                 processedText = try await OllamaPostProcessingService.process(
                     text: finalText,
                     baseURL: settings.ollamaBaseURL,
                     model: settings.ollamaModel,
                     reasoning: settings.ollamaReasoningSetting,
-                    prompt: settings.ollamaPostProcessingPrompt,
+                    prompt: prompt,
                     vocabulary: settings.customVocabulary
                 )
             } catch {
                 logger.error("postProcessing: Ollama failed: \(error.localizedDescription, privacy: .public)")
             }
         case .openRouter:
+            let prompt = AppPromptResolver.resolve(
+                bundleIdentifier: insertionTargetApp?.bundleIdentifier,
+                mappings: settings.appPromptMappings,
+                enabled: settings.appPromptMappingEnabled,
+                fallback: settings.openRouterPostProcessingPrompt
+            )
             do {
                 processedText = try await OpenRouterPostProcessingService.process(
                     text: finalText,
                     model: settings.openRouterModel,
-                    prompt: settings.openRouterPostProcessingPrompt,
+                    prompt: prompt,
                     vocabulary: settings.customVocabulary,
                     apiKey: settings.openRouterAPIKey,
                     apiKeyEnvironmentVariable: settings.openRouterAPIKeyEnvironmentVariable
@@ -758,13 +776,19 @@ final class AppState {
                 logger.error("postProcessing: OpenRouter failed: \(error.localizedDescription, privacy: .public)")
             }
         case .openAICompatible:
+            let prompt = AppPromptResolver.resolve(
+                bundleIdentifier: insertionTargetApp?.bundleIdentifier,
+                mappings: settings.appPromptMappings,
+                enabled: settings.appPromptMappingEnabled,
+                fallback: settings.openAICompatiblePostProcessingPrompt
+            )
             do {
                 processedText = try await OpenAICompatiblePostProcessingService.process(
                     text: finalText,
                     baseURL: settings.openAICompatibleBaseURL,
                     model: settings.openAICompatibleModel,
                     apiKey: settings.openAICompatibleAPIKey,
-                    prompt: settings.openAICompatiblePostProcessingPrompt,
+                    prompt: prompt,
                     vocabulary: settings.customVocabulary
                 )
             } catch {

--- a/Dictate Anywhere/Settings.swift
+++ b/Dictate Anywhere/Settings.swift
@@ -714,6 +714,8 @@ final class Settings {
         static let openAICompatiblePostProcessingPrompt = "openAICompatiblePostProcessingPrompt"
         static let inputSourceMappings = "inputSourceMappings"
         static let inputSourceAutoSwitchEnabled = "inputSourceAutoSwitchEnabled"
+        static let appPromptMappings = "appPromptMappings"
+        static let appPromptMappingEnabled = "appPromptMappingEnabled"
         static let pendingVocabularyModeRestore = "pendingVocabularyModeRestore"
     }
 
@@ -862,6 +864,19 @@ final class Settings {
     nonisolated static func resolvedAppPromptMappings(from data: Data?) -> [AppPromptMapping] {
         guard let data else { return preloadedAppPromptMappings }
         return (try? JSONDecoder().decode([AppPromptMapping].self, from: data)) ?? []
+    }
+
+    var appPromptMappings: [AppPromptMapping] {
+        didSet {
+            guard let data = try? JSONEncoder().encode(appPromptMappings) else { return }
+            UserDefaults.standard.set(data, forKey: Keys.appPromptMappings)
+        }
+    }
+
+    var appPromptMappingEnabled: Bool {
+        didSet {
+            UserDefaults.standard.set(appPromptMappingEnabled, forKey: Keys.appPromptMappingEnabled)
+        }
     }
 
     // MARK: - Filler Word Removal
@@ -1178,6 +1193,10 @@ final class Settings {
         inputSourceAutoSwitchEnabled = defaults.object(forKey: Keys.inputSourceAutoSwitchEnabled) as? Bool ?? false
         pendingVocabularyModeRestore = defaults.object(forKey: Keys.pendingVocabularyModeRestore) as? Bool ?? false
 
+        // App prompts
+        appPromptMappings = Self.resolvedAppPromptMappings(from: defaults.data(forKey: Keys.appPromptMappings))
+        appPromptMappingEnabled = defaults.object(forKey: Keys.appPromptMappingEnabled) as? Bool ?? true
+
         // Filler words
         isFillerWordRemovalEnabled = defaults.object(forKey: Keys.isFillerWordRemovalEnabled) as? Bool ?? false
         fillerWordsToRemove = defaults.object(forKey: Keys.fillerWordsToRemove) as? [String] ?? Self.defaultFillerWords
@@ -1418,6 +1437,33 @@ final class Settings {
 
     func mapping(forInputSourceID id: String) -> InputSourceMapping? {
         inputSourceMappings.first { $0.inputSourceID == id }
+    }
+
+    // MARK: - App Prompt Mapping Helpers
+
+    /// Adds a mapping for a not-yet-mapped bundle identifier with an empty
+    /// prompt, ready for the user to fill in. Returns nil (no-op) if a
+    /// mapping for this app already exists — one rule per app.
+    @discardableResult
+    func addAppPromptMapping(bundleIdentifier: String, appName: String) -> AppPromptMapping? {
+        guard !appPromptMappings.contains(where: { $0.bundleIdentifier == bundleIdentifier }) else { return nil }
+        let mapping = AppPromptMapping(
+            id: UUID(),
+            bundleIdentifier: bundleIdentifier,
+            appName: appName,
+            prompt: ""
+        )
+        appPromptMappings.append(mapping)
+        return mapping
+    }
+
+    func updateAppPromptMapping(_ mapping: AppPromptMapping) {
+        guard let index = appPromptMappings.firstIndex(where: { $0.id == mapping.id }) else { return }
+        appPromptMappings[index] = mapping
+    }
+
+    func removeAppPromptMapping(id: UUID) {
+        appPromptMappings.removeAll { $0.id == id }
     }
 
     /// Call right after an auto-switch may have driven the `parakeetModelChoice`

--- a/Dictate Anywhere/Settings.swift
+++ b/Dictate Anywhere/Settings.swift
@@ -866,6 +866,19 @@ final class Settings {
         return (try? JSONDecoder().decode([AppPromptMapping].self, from: data)) ?? []
     }
 
+    /// Master-toggle default for app prompts: `true` only on a genuinely
+    /// fresh install. `storedValue` (an explicit user choice, or a value
+    /// already persisted by a prior run of this same feature) always wins;
+    /// `isExistingInstall` only decides the default when nothing has ever
+    /// been stored, so upgrading users don't have preloaded per-app rules
+    /// silently activated over a global prompt they've already tuned.
+    nonisolated static func resolvedAppPromptMappingEnabled(
+        storedValue: Bool?,
+        isExistingInstall: Bool
+    ) -> Bool {
+        storedValue ?? !isExistingInstall
+    }
+
     var appPromptMappings: [AppPromptMapping] {
         didSet {
             guard let data = try? JSONEncoder().encode(appPromptMappings) else { return }
@@ -1195,7 +1208,18 @@ final class Settings {
 
         // App prompts
         appPromptMappings = Self.resolvedAppPromptMappings(from: defaults.data(forKey: Keys.appPromptMappings))
-        appPromptMappingEnabled = defaults.object(forKey: Keys.appPromptMappingEnabled) as? Bool ?? true
+        // Keys.transcriptPostProcessingMode is unconditionally persisted by the end of
+        // every completed Settings.init() (see the "Transcript Post Processing" block
+        // below, which writes it whenever it's absent). Since this check runs earlier
+        // in the same init(), it reflects state from *before* that write, so it reads
+        // nil only on a process's first-ever init — i.e. a genuinely fresh install —
+        // and non-nil on every later launch, including the first launch of this
+        // feature for anyone who ran a prior version of the app before.
+        let isExistingInstall = defaults.object(forKey: Keys.transcriptPostProcessingMode) != nil
+        appPromptMappingEnabled = Self.resolvedAppPromptMappingEnabled(
+            storedValue: defaults.object(forKey: Keys.appPromptMappingEnabled) as? Bool,
+            isExistingInstall: isExistingInstall
+        )
 
         // Filler words
         isFillerWordRemovalEnabled = defaults.object(forKey: Keys.isFillerWordRemovalEnabled) as? Bool ?? false

--- a/Dictate Anywhere/Settings.swift
+++ b/Dictate Anywhere/Settings.swift
@@ -553,6 +553,18 @@ private struct RawInputSourceMapping: Decodable {
     let language: String
 }
 
+/// One user-configured app (by bundle identifier) → cleanup-prompt mapping.
+/// The prompt fully replaces whichever post-processing provider's global
+/// prompt is active when the bundle identifier matches the frontmost app at
+/// dictation time — never appended, never provider-specific.
+struct AppPromptMapping: Codable, Identifiable, Equatable {
+    var id: UUID
+    var bundleIdentifier: String
+    /// Cached for display even when the app isn't currently running.
+    var appName: String
+    var prompt: String
+}
+
 struct TranscriptHistoryEntry: Identifiable, Codable, Equatable {
     let id: UUID
     let text: String
@@ -622,6 +634,35 @@ final class Settings {
 
     Treat custom vocabulary as a strong hint, not a hard rule. If a suggested term does not semantically fit the sentence, prefer the wording that best matches the surrounding context.
     """
+    /// Shipped on first launch so per-app prompts are useful with zero
+    /// configuration. Purely a seed value — every row is user-editable and
+    /// deletable afterward like any other mapping.
+    nonisolated static let preloadedAppPromptMappings: [AppPromptMapping] = [
+        AppPromptMapping(
+            id: UUID(),
+            bundleIdentifier: "com.apple.MobileSMS",
+            appName: "Messages",
+            prompt: "Write like a text message: casual and conversational. Contractions are fine, and you don't need every sentence to end with a period. Keep it brief and to the point."
+        ),
+        AppPromptMapping(
+            id: UUID(),
+            bundleIdentifier: "com.tinyspeck.slackmacgap",
+            appName: "Slack",
+            prompt: "Write in a casual, professional workplace tone. Short sentences are fine, and you don't need a greeting or sign-off. Light, natural punctuation."
+        ),
+        AppPromptMapping(
+            id: UUID(),
+            bundleIdentifier: "com.apple.mail",
+            appName: "Mail",
+            prompt: "Write in a polished, professional email tone. Use complete sentences and proper grammar. If the dictation reads like a full email, include an appropriate greeting and sign-off."
+        ),
+        AppPromptMapping(
+            id: UUID(),
+            bundleIdentifier: "com.microsoft.VSCode",
+            appName: "VS Code",
+            prompt: "Preserve code identifiers, file paths, and technical terms exactly as spoken — do not autocorrect or rewrite them. Keep the result terse, like a code comment or commit message. No filler words."
+        ),
+    ]
     private nonisolated static let functionKeyCodes: Set<UInt16> = [63, 179]
     private nonisolated static let openRouterAPIKeyKeychainAccount = "openrouter-api-key"
     private nonisolated static let openAICompatibleAPIKeyKeychainAccount = "openai-compatible-api-key"
@@ -809,6 +850,18 @@ final class Settings {
                 language: language
             )
         }
+    }
+
+    // MARK: - App Prompts
+
+    /// Resolves the array to persist and expose at launch: the preloaded
+    /// samples when no value has ever been stored (`data == nil`, i.e. this
+    /// key has never been written), the decoded array otherwise — including
+    /// an intentionally empty array a user saved by deleting every rule.
+    /// Undecodable data falls back to empty, matching `sanitizedMappings(from:)`.
+    nonisolated static func resolvedAppPromptMappings(from data: Data?) -> [AppPromptMapping] {
+        guard let data else { return preloadedAppPromptMappings }
+        return (try? JSONDecoder().decode([AppPromptMapping].self, from: data)) ?? []
     }
 
     // MARK: - Filler Word Removal

--- a/Dictate AnywhereTests/AppPromptMappingTests.swift
+++ b/Dictate AnywhereTests/AppPromptMappingTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import Dictate_Anywhere_Dev
+
+final class AppPromptMappingTests: XCTestCase {
+    private func mapping(
+        bundleIdentifier: String = "com.example.app",
+        appName: String = "Example",
+        prompt: String = "Be casual."
+    ) -> AppPromptMapping {
+        AppPromptMapping(id: UUID(), bundleIdentifier: bundleIdentifier, appName: appName, prompt: prompt)
+    }
+
+    func testMappingRoundTripsThroughJSON() throws {
+        let mappings = [
+            mapping(),
+            mapping(bundleIdentifier: "com.apple.mail", appName: "Mail", prompt: "Be formal."),
+        ]
+        let data = try JSONEncoder().encode(mappings)
+        XCTAssertEqual(Settings.resolvedAppPromptMappings(from: data), mappings)
+    }
+
+    func testResolvedMappingsReturnsPreloadedSeedWhenDataIsNil() {
+        XCTAssertEqual(Settings.resolvedAppPromptMappings(from: nil), Settings.preloadedAppPromptMappings)
+    }
+
+    func testResolvedMappingsReturnsEmptyArrayWhenStoredExplicitlyEmpty() throws {
+        let data = try JSONEncoder().encode([AppPromptMapping]())
+        XCTAssertEqual(Settings.resolvedAppPromptMappings(from: data), [])
+    }
+
+    func testResolvedMappingsReturnsEmptyOnGarbageData() {
+        XCTAssertTrue(Settings.resolvedAppPromptMappings(from: Data("not json".utf8)).isEmpty)
+    }
+
+    func testPreloadedMappingsCoverExpectedApps() {
+        let bundleIDs = Set(Settings.preloadedAppPromptMappings.map(\.bundleIdentifier))
+        XCTAssertEqual(bundleIDs, [
+            "com.apple.MobileSMS",
+            "com.tinyspeck.slackmacgap",
+            "com.apple.mail",
+            "com.microsoft.VSCode",
+        ])
+    }
+
+    func testPreloadedMappingsHaveUniqueIDs() {
+        let ids = Settings.preloadedAppPromptMappings.map(\.id)
+        XCTAssertEqual(ids.count, Set(ids).count)
+    }
+}

--- a/Dictate AnywhereTests/AppPromptMappingTests.swift
+++ b/Dictate AnywhereTests/AppPromptMappingTests.swift
@@ -47,6 +47,26 @@ final class AppPromptMappingTests: XCTestCase {
         XCTAssertEqual(ids.count, Set(ids).count)
     }
 
+    // MARK: - resolvedAppPromptMappingEnabled
+
+    func testResolvedMappingEnabledDefaultsTrueOnFreshInstall() {
+        XCTAssertTrue(Settings.resolvedAppPromptMappingEnabled(storedValue: nil, isExistingInstall: false))
+    }
+
+    func testResolvedMappingEnabledDefaultsFalseOnExistingInstall() {
+        XCTAssertFalse(Settings.resolvedAppPromptMappingEnabled(storedValue: nil, isExistingInstall: true))
+    }
+
+    func testResolvedMappingEnabledHonorsStoredTrueRegardlessOfInstallAge() {
+        XCTAssertTrue(Settings.resolvedAppPromptMappingEnabled(storedValue: true, isExistingInstall: true))
+        XCTAssertTrue(Settings.resolvedAppPromptMappingEnabled(storedValue: true, isExistingInstall: false))
+    }
+
+    func testResolvedMappingEnabledHonorsStoredFalseRegardlessOfInstallAge() {
+        XCTAssertFalse(Settings.resolvedAppPromptMappingEnabled(storedValue: false, isExistingInstall: true))
+        XCTAssertFalse(Settings.resolvedAppPromptMappingEnabled(storedValue: false, isExistingInstall: false))
+    }
+
     // MARK: - Settings persistence & CRUD
 
     private var savedAppPromptMappings: [AppPromptMapping] = []

--- a/Dictate AnywhereTests/AppPromptMappingTests.swift
+++ b/Dictate AnywhereTests/AppPromptMappingTests.swift
@@ -46,4 +46,66 @@ final class AppPromptMappingTests: XCTestCase {
         let ids = Settings.preloadedAppPromptMappings.map(\.id)
         XCTAssertEqual(ids.count, Set(ids).count)
     }
+
+    // MARK: - Settings persistence & CRUD
+
+    private var savedAppPromptMappings: [AppPromptMapping] = []
+    private var savedAppPromptMappingEnabled = false
+
+    override func setUp() {
+        super.setUp()
+        let settings = Settings.shared
+        savedAppPromptMappings = settings.appPromptMappings
+        savedAppPromptMappingEnabled = settings.appPromptMappingEnabled
+    }
+
+    override func tearDown() {
+        let settings = Settings.shared
+        settings.appPromptMappings = savedAppPromptMappings
+        settings.appPromptMappingEnabled = savedAppPromptMappingEnabled
+        super.tearDown()
+    }
+
+    func testMappingsPersistToUserDefaults() throws {
+        let settings = Settings.shared
+        let entry = mapping(bundleIdentifier: "com.apple.mail", appName: "Mail", prompt: "Be formal.")
+        settings.appPromptMappings = [entry]
+        let data = try XCTUnwrap(UserDefaults.standard.data(forKey: "appPromptMappings"))
+        XCTAssertEqual(Settings.resolvedAppPromptMappings(from: data), [entry])
+    }
+
+    func testAddAppPromptMappingAppendsNewEntry() {
+        let settings = Settings.shared
+        settings.appPromptMappings = []
+        let added = settings.addAppPromptMapping(bundleIdentifier: "com.apple.mail", appName: "Mail")
+        XCTAssertEqual(added?.bundleIdentifier, "com.apple.mail")
+        XCTAssertEqual(added?.prompt, "")
+        XCTAssertEqual(settings.appPromptMappings.map(\.bundleIdentifier), ["com.apple.mail"])
+    }
+
+    func testAddAppPromptMappingRejectsDuplicateBundleIdentifier() {
+        let settings = Settings.shared
+        settings.appPromptMappings = [mapping(bundleIdentifier: "com.apple.mail")]
+        let added = settings.addAppPromptMapping(bundleIdentifier: "com.apple.mail", appName: "Mail")
+        XCTAssertNil(added)
+        XCTAssertEqual(settings.appPromptMappings.count, 1)
+    }
+
+    func testUpdateAppPromptMappingReplacesPromptText() {
+        let settings = Settings.shared
+        let entry = mapping()
+        settings.appPromptMappings = [entry]
+        var updated = entry
+        updated.prompt = "New prompt."
+        settings.updateAppPromptMapping(updated)
+        XCTAssertEqual(settings.appPromptMappings.first?.prompt, "New prompt.")
+    }
+
+    func testRemoveAppPromptMappingDeletesEntry() {
+        let settings = Settings.shared
+        let entry = mapping()
+        settings.appPromptMappings = [entry]
+        settings.removeAppPromptMapping(id: entry.id)
+        XCTAssertTrue(settings.appPromptMappings.isEmpty)
+    }
 }

--- a/Dictate AnywhereTests/AppPromptResolverTests.swift
+++ b/Dictate AnywhereTests/AppPromptResolverTests.swift
@@ -59,4 +59,24 @@ final class AppPromptResolverTests: XCTestCase {
         )
         XCTAssertEqual(resolved, "Default prompt.")
     }
+
+    func testMatchWithEmptyPromptReturnsFallback() {
+        let resolved = AppPromptResolver.resolve(
+            bundleIdentifier: "com.apple.mail",
+            mappings: [mapping(prompt: "")],
+            enabled: true,
+            fallback: "Default prompt."
+        )
+        XCTAssertEqual(resolved, "Default prompt.")
+    }
+
+    func testMatchWithWhitespaceOnlyPromptReturnsFallback() {
+        let resolved = AppPromptResolver.resolve(
+            bundleIdentifier: "com.apple.mail",
+            mappings: [mapping(prompt: "   \n\t  ")],
+            enabled: true,
+            fallback: "Default prompt."
+        )
+        XCTAssertEqual(resolved, "Default prompt.")
+    }
 }

--- a/Dictate AnywhereTests/AppPromptResolverTests.swift
+++ b/Dictate AnywhereTests/AppPromptResolverTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import Dictate_Anywhere_Dev
+
+/// Pure resolution tests — no Settings.shared mutation, no snapshot needed.
+final class AppPromptResolverTests: XCTestCase {
+    private func mapping(
+        bundleIdentifier: String = "com.apple.mail",
+        prompt: String = "Be formal."
+    ) -> AppPromptMapping {
+        AppPromptMapping(id: UUID(), bundleIdentifier: bundleIdentifier, appName: "Mail", prompt: prompt)
+    }
+
+    func testExactMatchReturnsMappedPrompt() {
+        let resolved = AppPromptResolver.resolve(
+            bundleIdentifier: "com.apple.mail",
+            mappings: [mapping()],
+            enabled: true,
+            fallback: "Default prompt."
+        )
+        XCTAssertEqual(resolved, "Be formal.")
+    }
+
+    func testNoMatchReturnsFallback() {
+        let resolved = AppPromptResolver.resolve(
+            bundleIdentifier: "com.example.unmapped",
+            mappings: [mapping()],
+            enabled: true,
+            fallback: "Default prompt."
+        )
+        XCTAssertEqual(resolved, "Default prompt.")
+    }
+
+    func testDisabledReturnsFallbackEvenWithMatch() {
+        let resolved = AppPromptResolver.resolve(
+            bundleIdentifier: "com.apple.mail",
+            mappings: [mapping()],
+            enabled: false,
+            fallback: "Default prompt."
+        )
+        XCTAssertEqual(resolved, "Default prompt.")
+    }
+
+    func testNilBundleIdentifierReturnsFallback() {
+        let resolved = AppPromptResolver.resolve(
+            bundleIdentifier: nil,
+            mappings: [mapping()],
+            enabled: true,
+            fallback: "Default prompt."
+        )
+        XCTAssertEqual(resolved, "Default prompt.")
+    }
+
+    func testEmptyMappingsReturnsFallback() {
+        let resolved = AppPromptResolver.resolve(
+            bundleIdentifier: "com.apple.mail",
+            mappings: [],
+            enabled: true,
+            fallback: "Default prompt."
+        )
+        XCTAssertEqual(resolved, "Default prompt.")
+    }
+}


### PR DESCRIPTION
## Summary
- Lets users define a different transcript-cleanup prompt per frontmost app (e.g. casual for Messages, formal for Mail, terse for VS Code), matched by exact bundle identifier
- One prompt per app, used by whichever post-processing provider (Apple Intelligence, Ollama, OpenRouter, OpenAI-compatible) is currently active — never a per-provider variant, and unmatched/disabled apps fall back to today's existing global prompt unchanged
- Ships with 4 preloaded sample rules (Messages, Slack, Mail, VS Code); existing installs get the rows seeded but inactive by default (opt-in toggle) so nobody's already-tuned global prompt is silently overridden on upgrade — fresh installs default to active
- New "App Prompts" section in the Transcript Cleanup settings page, full add/edit/delete UI

## Test plan
- [x] `xcodebuild test` — 238/238 tests passing (8 skipped), including new `AppPromptMappingTests` and `AppPromptResolverTests`
- [x] Debug build succeeds, no new warnings
- [x] Manual: toggle on/off, dictate into a preloaded app, add a custom app rule, delete a preloaded rule and relaunch to confirm it doesn't reseed

Design doc and implementation plan available on request (kept local-only per this fork's convention, not included in the diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)