### PR TITLE
Fix debug app isolation

### DIFF
--- a/Dictate Anywhere.xcodeproj/project.pbxproj
+++ b/Dictate Anywhere.xcodeproj/project.pbxproj
@@ -366,6 +366,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Dictate Anywhere/Info.plist";
+				INFOPLIST_PREPROCESS = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = "Dictate Anywhere Dev";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_LSUIElement = YES;
@@ -407,6 +408,8 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Dictate Anywhere/Info.plist";
+				INFOPLIST_PREPROCESS = YES;
+				INFOPLIST_PREPROCESSOR_DEFINITIONS = "RELEASE=1";
 				INFOPLIST_KEY_CFBundleDisplayName = "Dictate Anywhere";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_LSUIElement = YES;

--- a/Dictate Anywhere.xcodeproj/xcshareddata/xcschemes/Dictate Anywhere.xcscheme
+++ b/Dictate Anywhere.xcodeproj/xcshareddata/xcschemes/Dictate Anywhere.xcscheme
@@ -16,7 +16,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "E2A66B572F18203C00DABF41"
-               BuildableName = "Dictate Anywhere.app"
+               BuildableName = "Dictate Anywhere Dev.app"
                BlueprintName = "Dictate Anywhere"
                ReferencedContainer = "container:Dictate Anywhere.xcodeproj">
             </BuildableReference>
@@ -64,7 +64,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "E2A66B572F18203C00DABF41"
-            BuildableName = "Dictate Anywhere.app"
+            BuildableName = "Dictate Anywhere Dev.app"
             BlueprintName = "Dictate Anywhere"
             ReferencedContainer = "container:Dictate Anywhere.xcodeproj">
          </BuildableReference>

--- a/Dictate Anywhere/App.swift
+++ b/Dictate Anywhere/App.swift
@@ -23,9 +23,11 @@ struct DictateAnywhereApp: App {
             CommandGroup(replacing: .newItem) {
                 Button("Open Dictate Anywhere", action: appDelegate.showMainWindow)
             }
+#if !DEBUG
             CommandGroup(after: .appInfo) {
                 CheckForUpdatesView(updater: appDelegate.softwareUpdater)
             }
+#endif
         }
     }
 }

--- a/Dictate Anywhere/AppDelegate.swift
+++ b/Dictate Anywhere/AppDelegate.swift
@@ -10,7 +10,9 @@ import SwiftUI
 
 final class AppDelegate: NSObject, NSApplicationDelegate {
     let appState = AppState()
+#if !DEBUG
     let softwareUpdater = SoftwareUpdater()
+#endif
     private var statusItem: NSStatusItem?
     private var mainWindow: NSWindow?
 
@@ -81,9 +83,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         vocabItem.target = self
         menu.addItem(vocabItem)
 
+#if !DEBUG
         let updateItem = NSMenuItem(title: "Check for Updates...", action: #selector(checkForUpdates), keyEquivalent: "")
         updateItem.target = self
         menu.addItem(updateItem)
+#endif
 
         menu.addItem(NSMenuItem.separator())
 
@@ -204,9 +208,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         NSPasteboard.general.setString(transcript, forType: .string)
     }
 
+#if !DEBUG
     @objc private func checkForUpdates() {
         softwareUpdater.checkForUpdates()
     }
+#endif
 
     @objc private func selectMicrophone(_ sender: NSMenuItem) {
         Settings.shared.selectedMicrophoneUID = sender.representedObject as? String

--- a/Dictate Anywhere/Info.plist
+++ b/Dictate Anywhere/Info.plist
@@ -4,9 +4,12 @@
 <dict>
 	<key>ATSApplicationFontsPath</key>
 	<string>.</string>
+#if RELEASE
+	<!-- The // is encoded because Xcode's Info.plist C-preprocessor treats it as a comment when INFOPLIST_PREPROCESS=YES. -->
 	<key>SUFeedURL</key>
-	<string>https://raw.githubusercontent.com/hoomanaskari/mac-dictate-anywhere/main/appcast.xml</string>
+	<string>https:&#x2F;&#x2F;raw.githubusercontent.com/hoomanaskari/mac-dictate-anywhere/main/appcast.xml</string>
 	<key>SUPublicEDKey</key>
 	<string>z7u+QuecsTX6G6rpZUEFQofMbF4bkEk6JdHh6/q370k=</string>
+#endif
 </dict>
 </plist>

--- a/Dictate Anywhere/SoftwareUpdater.swift
+++ b/Dictate Anywhere/SoftwareUpdater.swift
@@ -5,6 +5,7 @@
 //  Sparkle auto-update wrapper.
 //
 
+#if !DEBUG
 import Sparkle
 import SwiftUI
 
@@ -66,3 +67,4 @@ struct CheckForUpdatesView: View {
         }
     }
 }
+#endif


### PR DESCRIPTION
Thanks a ton for this amazing app, really enjoying using it! :-)
It stands out from the 100s of other ASR/STT apps, with its beautiful UI+UX and clean architecture and high performance - I've been searching for something like this for a while.

This PR separates the Debug app from the production Release app during development. This prevents both builds from overwriting each other while new features are tested.

### Changes

- Launch Debug as `Dictate Anywhere Dev.app`.
- Use the development bundle identifier `com.pixelforty.dictate-anywhere.dev`.
- Prevent Debug from initializing Sparkle.
- Remove update commands from Debug.
- Keep the production Sparkle metadata and update behavior in Release.

### Not changed

- FluidAudio model storage or shared model files.
- Hotkey and audio behavior.
- Login-item behavior.
- Permission request logic.
- Production app identity or update behavior.

### Verification

- Debug build passed.
- Release build passed with signing disabled.
- Debug updater metadata and linkage are absent.
- Release updater metadata and linkage are present.