### PR TITLE
Gracefully shut down app services before exit

### DIFF
--- a/Dictate Anywhere/AppDelegate.swift
+++ b/Dictate Anywhere/AppDelegate.swift
@@ -19,6 +19,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var customVocabularyMenuItem: NSMenuItem?
     private var cancelDictationMenuItem: NSMenuItem?
     private var stopDictationMenuItem: NSMenuItem?
+    private var isTerminating = false
 
     override init() {
         self.appState = AppState()
@@ -61,6 +62,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
         false
+    }
+
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        guard !isTerminating else { return .terminateLater }
+        isTerminating = true
+
+        // llama.cpp's Metal backend must release its model buffers before AppKit
+        // begins process teardown, including Sparkle's update-and-relaunch path.
+        Task { [weak self] in
+            await self?.appState.shutdown()
+            await S1MiniPostProcessingService.unload()
+            sender.reply(toApplicationShouldTerminate: true)
+            self?.isTerminating = false
+        }
+        return .terminateLater
     }
 
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {

--- a/Dictate Anywhere/AppState.swift
+++ b/Dictate Anywhere/AppState.swift
@@ -776,7 +776,10 @@ final class AppState {
             }
 
             do {
-                let startTask = Task { try await engine.startRecording(deviceID: candidateID) }
+                let startTask = Task {
+                    try Task.checkCancellation()
+                    try await engine.startRecording(deviceID: candidateID)
+                }
                 recordingStartTask = startTask
                 try await startTask.value
                 recordingStartTask = nil

--- a/Dictate Anywhere/AppState.swift
+++ b/Dictate Anywhere/AppState.swift
@@ -241,15 +241,43 @@ final class AppState {
         startupTask = nil
         inputSourceApplyTask?.cancel()
         inputSourceApplyTask = nil
+        activeRecordingStartupID = nil
+        processingTask?.cancel()
         stopAudioLevelPolling()
         inputSourceMonitor.stopMonitoring()
         hotkeyService.stopMonitoring()
         permissions.stopPolling()
 
-        await parakeetEngine.cancel()
-        await appleSpeechEngine.cancel()
+        // A cancelled finish task must unwind before its engine can be unloaded.
+        await processingTask?.value
+        processingTask = nil
+        processingOperationID = nil
+
+        let engine = sessionEngine ?? activeEngine
+        await engine.cancel()
+        if engine !== parakeetEngine { await parakeetEngine.cancel() }
+        if engine !== appleSpeechEngine { await appleSpeechEngine.cancel() }
         await appleSpeechEngine.invalidatePreparedSession()
 
+        recoveryCapture = nil
+        completedRecognitionTranscript = nil
+        engine.recoveryCapture = nil
+        engine.setSessionContextualVocabulary([])
+        clearEndOfUtteranceHandler(for: engine)
+        sessionEngine = nil
+        sessionHotkeyMode = nil
+        continuingEntryID = nil
+        recoveringEntryID = nil
+        transcriptPrefix = ""
+        previousRecordingDuration = 0
+        continuationTargetBundleIdentifier = nil
+        insertionTargetApp = nil
+        sessionDictationContext = nil
+        currentTranscript = ""
+        isDeliveringTranscript = false
+        isCancelling = false
+        isTransitioning = false
+        status = .idle
         volumeController.restoreMicrophoneVolume()
         volumeController.restoreAfterRecording()
         overlay.hide(afterDelay: 0)
@@ -612,12 +640,14 @@ final class AppState {
             permissions.micGranted = true
             return // The permission gesture must never become a recording gesture.
         }
+        guard !isShuttingDown else { return }
         if settings.inputSourceAutoSwitchEnabled,
            let inputSourceID = inputSourceMonitor.currentInputSourceID() {
             // Backstop: the eager pre-warm usually already did this; going
             // through the queue serializes against an apply still in flight.
             await enqueueInputSourceProfileApply(for: inputSourceID, showLoadingOverlay: true).value
         }
+        guard !isShuttingDown else { return }
         let engine = activeEngine
         switch settings.engineChoice {
         case .parakeet:
@@ -652,11 +682,14 @@ final class AppState {
                 return
             }
         }
+        guard !isShuttingDown else { return }
         await captureInsertionTargetAppAndContext()
+        guard !isShuttingDown else { return }
         await beginRecording(engine: engine, mode: mode)
     }
 
     private func beginRecording(engine: TranscriptionEngine, mode: HotkeyMode?) async {
+        guard !isShuttingDown else { return }
         engine.setSessionContextualVocabulary(sessionDictationContext?.lexicalHints ?? [])
 
         isTransitioning = true
@@ -726,25 +759,25 @@ final class AppState {
             : nil
         var didStart = false
         for (index, candidateID) in startCandidates.enumerated() {
-            guard activeRecordingStartupID == recordingStartupID else { return }
+            guard !isShuttingDown, activeRecordingStartupID == recordingStartupID else { return }
             if index > 0 {
                 logger.warning(
                     "startDictation: retrying startRecording attempt \(index + 1, privacy: .public) with deviceID=\(candidateID.map { String($0) } ?? "nil", privacy: .public)"
                 )
                 try? await Task.sleep(for: .milliseconds(220))
-                guard activeRecordingStartupID == recordingStartupID else { return }
+                guard !isShuttingDown, activeRecordingStartupID == recordingStartupID else { return }
             }
 
             do {
                 try await engine.startRecording(deviceID: candidateID)
-                guard activeRecordingStartupID == recordingStartupID else { return }
+                guard !isShuttingDown, activeRecordingStartupID == recordingStartupID else { return }
                 didStart = true
                 logger.info(
                     "startDictation: startRecording succeeded on attempt \(index + 1, privacy: .public), deviceID=\(candidateID.map { String($0) } ?? "nil", privacy: .public)"
                 )
                 break
             } catch {
-                guard activeRecordingStartupID == recordingStartupID else { return }
+                guard !isShuttingDown, activeRecordingStartupID == recordingStartupID else { return }
                 lastStartError = error
                 logger.error(
                     "startDictation: startRecording attempt \(index + 1, privacy: .public) failed: \(error.localizedDescription, privacy: .public)"
@@ -752,6 +785,7 @@ final class AppState {
             }
         }
 
+        guard !isShuttingDown else { return }
         guard didStart else {
             let wasContinuing = continuingEntryID != nil
             await discardSessionRecovery()
@@ -781,6 +815,7 @@ final class AppState {
         }
 
         // Show overlay only after mic is confirmed active
+        guard !isShuttingDown else { return }
         overlay.show(state: .listening(level: 0, transcript: currentTranscript))
 
         // Start audio level polling
@@ -1184,7 +1219,7 @@ final class AppState {
     }
 
     func continueCancelledDictation(_ entry: CancelledDictation) async {
-        guard status == .idle, !isTransitioning else { return }
+        guard !isShuttingDown, status == .idle, !isTransitioning else { return }
         isTransitioning = true
         defer { if status != .recording { isTransitioning = false } }
         if !permissions.micGranted {
@@ -1208,6 +1243,7 @@ final class AppState {
             if !engine.isReady { try await engine.prepare() }
             let restored = try await restoredTranscript(for: saved, engine: engine)
             try Task.checkCancellation()
+            guard !isShuttingDown else { return }
             guard !restored.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
                 throw NSError(domain: "DictationRecovery", code: 2, userInfo: [NSLocalizedDescriptionKey:
                     "No speech was restored. Try Recover text with a different speech model."])
@@ -1221,6 +1257,7 @@ final class AppState {
             await captureInsertionTargetAppAndContext(target: target, useFrontmost: false)
             await reactivateInsertionTargetIfNeeded()
             try Task.checkCancellation()
+            guard !isShuttingDown else { return }
             recoveringEntryID = nil
             await beginRecording(engine: engine, mode: .handsFreeToggle)
         } catch {

--- a/Dictate Anywhere/AppState.swift
+++ b/Dictate Anywhere/AppState.swift
@@ -232,6 +232,26 @@ final class AppState {
         }
     }
 
+    /// Stops process-lifetime services before AppKit tears down the process.
+    func shutdown() async {
+        startupTask?.cancel()
+        startupTask = nil
+        inputSourceApplyTask?.cancel()
+        inputSourceApplyTask = nil
+        stopAudioLevelPolling()
+        inputSourceMonitor.stopMonitoring()
+        hotkeyService.stopMonitoring()
+        permissions.stopPolling()
+
+        await parakeetEngine.cancel()
+        await appleSpeechEngine.cancel()
+        await appleSpeechEngine.invalidatePreparedSession()
+
+        volumeController.restoreMicrophoneVolume()
+        volumeController.restoreAfterRecording()
+        overlay.hide(afterDelay: 0)
+    }
+
     private func runStartupSequence() async {
         await permissions.check()
         updateAccessibilityIntegration(granted: permissions.accessibilityGranted, promptIfNeeded: true)

--- a/Dictate Anywhere/AppState.swift
+++ b/Dictate Anywhere/AppState.swift
@@ -118,6 +118,7 @@ final class AppState {
     private var activeRecordingStartupID: UUID?
     private var startupTask: Task<Void, Never>?
     private var hasStarted = false
+    private var isShuttingDown = false
 
     /// Serializes profile applies; a change arriving mid-apply queues behind it.
     private var inputSourceApplyTask: Task<Void, Never>?
@@ -220,7 +221,7 @@ final class AppState {
     }
 
     func start() {
-        guard !hasStarted else { return }
+        guard !hasStarted, !isShuttingDown else { return }
         hasStarted = true
         do { try recoveryStore.reload() } catch { recoveryStore.errorMessage = error.localizedDescription }
 
@@ -234,6 +235,8 @@ final class AppState {
 
     /// Stops process-lifetime services before AppKit tears down the process.
     func shutdown() async {
+        guard !isShuttingDown else { return }
+        isShuttingDown = true
         startupTask?.cancel()
         startupTask = nil
         inputSourceApplyTask?.cancel()
@@ -254,9 +257,12 @@ final class AppState {
 
     private func runStartupSequence() async {
         await permissions.check()
+        guard !isShuttingDown else { return }
         updateAccessibilityIntegration(granted: permissions.accessibilityGranted, promptIfNeeded: true)
         await prepareActiveEngine()
+        guard !isShuttingDown else { return }
         await refreshAppleSpeechAssetState()
+        guard !isShuttingDown else { return }
         inputSourceMonitor.startMonitoring()
         if settings.inputSourceAutoSwitchEnabled,
            let inputSourceID = inputSourceMonitor.currentInputSourceID() {
@@ -269,6 +275,7 @@ final class AppState {
     }
 
     private func updateAccessibilityIntegration(granted: Bool, promptIfNeeded: Bool) {
+        guard !isShuttingDown else { return }
         if granted {
             permissions.stopPolling()
             if (settings.hasHotkey || settings.cancelShortcut.hasBinding) && !hotkeyService.isMonitoring {
@@ -286,6 +293,7 @@ final class AppState {
     // MARK: - Engine Lifecycle
 
     func prepareActiveEngine() async {
+        guard !isShuttingDown else { return }
         logger.info("prepareActiveEngine: called, engineChoice=\(String(describing: self.settings.engineChoice), privacy: .public), status=\(String(describing: self.status), privacy: .public)")
         if case .recording = status { return }
         if case .processing = status { return }
@@ -296,7 +304,9 @@ final class AppState {
             // Auto-default: if the user hasn't explicitly chosen an engine and
             // a speech model is downloaded, ensure FluidAudio is selected.
             await parakeetEngine.recheckAllModelsOnDisk()
+            guard !isShuttingDown else { return }
             await parakeetEngine.handleSelectedModelChange()
+            guard !isShuttingDown else { return }
             let hasSpeechModel = parakeetEngine.checkAnyModelOnDisk()
             if !settings.userHasChosenEngine, hasSpeechModel {
                 settings.engineChoice = .parakeet
@@ -306,6 +316,7 @@ final class AppState {
             }
         case .appleSpeech:
             await refreshAppleSpeechAssetState()
+            guard !isShuttingDown else { return }
             if !appleSpeechSupportedLanguages.contains(settings.appleSpeechLanguage),
                let fallback = appleSpeechSupportedLanguages.first {
                 settings.appleSpeechLanguage = fallback
@@ -321,11 +332,20 @@ final class AppState {
             enginePreparationError = nil
             do {
                 try await activeEngine.prepare()
+                guard !isShuttingDown else {
+                    await activeEngine.cancel()
+                    return
+                }
             } catch {
                 logger.error("prepareActiveEngine: prepare() failed on first attempt: \(error.localizedDescription, privacy: .public)")
                 try? await Task.sleep(for: .seconds(1))
+                guard !isShuttingDown else { return }
                 do {
                     try await activeEngine.prepare()
+                    guard !isShuttingDown else {
+                        await activeEngine.cancel()
+                        return
+                    }
                 } catch {
                     logger.error("prepareActiveEngine: prepare() failed on retry: \(error.localizedDescription, privacy: .public)")
                     enginePreparationError = error.localizedDescription
@@ -338,6 +358,7 @@ final class AppState {
         // clears without waiting for settings to reopen.
         if settings.engineChoice == .appleSpeech {
             appleSpeechInstalledLanguages = await AppleSpeechEngine.installedLanguages()
+            guard !isShuttingDown else { return }
         }
         isPreparingEngine = false
     }
@@ -402,6 +423,7 @@ final class AppState {
     }
 
     func applyInputSourceProfile(for inputSourceID: String, showLoadingOverlay: Bool = false) async {
+        guard !isShuttingDown else { return }
         // Looked up (and, for Apple Speech, awaited) before the idle guard so
         // no suspension point lands between the guard and the settings
         // writes below — an in-flight recording-start guard check must never
@@ -410,6 +432,7 @@ final class AppState {
         let installedAppleSpeechLanguages = mapping?.engine == .appleSpeech
             ? await AppleSpeechEngine.installedLanguages()
             : []
+        guard !isShuttingDown else { return }
         guard status == .idle else { return }
         if mapping?.engine == .appleSpeech {
             appleSpeechInstalledLanguages = installedAppleSpeechLanguages
@@ -567,6 +590,7 @@ final class AppState {
     // MARK: - Dictation Flow
 
     func startDictation(mode: HotkeyMode? = nil) async {
+        guard !isShuttingDown else { return }
         logger.info("startDictation: entry, status=\(String(describing: self.status), privacy: .public), isTransitioning=\(self.isTransitioning, privacy: .public), engineChoice=\(String(describing: self.settings.engineChoice), privacy: .public)")
         if case .error = status {
             status = .idle

--- a/Dictate Anywhere/AppState.swift
+++ b/Dictate Anywhere/AppState.swift
@@ -116,6 +116,7 @@ final class AppState {
     private var sessionEngine: TranscriptionEngine?
     private var sessionHotkeyMode: HotkeyMode?
     private var activeRecordingStartupID: UUID?
+    private var recordingStartTask: Task<Void, Error>?
     private var startupTask: Task<Void, Never>?
     private var hasStarted = false
     private var isShuttingDown = false
@@ -242,6 +243,8 @@ final class AppState {
         inputSourceApplyTask?.cancel()
         inputSourceApplyTask = nil
         activeRecordingStartupID = nil
+        let recordingStartTask = recordingStartTask
+        recordingStartTask?.cancel()
         processingTask?.cancel()
         stopAudioLevelPolling()
         inputSourceMonitor.stopMonitoring()
@@ -255,6 +258,10 @@ final class AppState {
 
         let engine = sessionEngine ?? activeEngine
         await engine.cancel()
+        if let recordingStartTask {
+            _ = try? await recordingStartTask.value
+        }
+        self.recordingStartTask = nil
         if engine !== parakeetEngine { await parakeetEngine.cancel() }
         if engine !== appleSpeechEngine { await appleSpeechEngine.cancel() }
         await appleSpeechEngine.invalidatePreparedSession()
@@ -769,7 +776,10 @@ final class AppState {
             }
 
             do {
-                try await engine.startRecording(deviceID: candidateID)
+                let startTask = Task { try await engine.startRecording(deviceID: candidateID) }
+                recordingStartTask = startTask
+                try await startTask.value
+                recordingStartTask = nil
                 guard !isShuttingDown, activeRecordingStartupID == recordingStartupID else { return }
                 didStart = true
                 logger.info(
@@ -777,6 +787,7 @@ final class AppState {
                 )
                 break
             } catch {
+                recordingStartTask = nil
                 guard !isShuttingDown, activeRecordingStartupID == recordingStartupID else { return }
                 lastStartError = error
                 logger.error(

--- a/Dictate Anywhere/AppState.swift
+++ b/Dictate Anywhere/AppState.swift
@@ -1254,7 +1254,10 @@ final class AppState {
             if !engine.isReady { try await engine.prepare() }
             let restored = try await restoredTranscript(for: saved, engine: engine)
             try Task.checkCancellation()
-            guard !isShuttingDown else { return }
+            guard !isShuttingDown else {
+                recoveryStore.release(id: saved.id)
+                return
+            }
             guard !restored.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
                 throw NSError(domain: "DictationRecovery", code: 2, userInfo: [NSLocalizedDescriptionKey:
                     "No speech was restored. Try Recover text with a different speech model."])
@@ -1268,7 +1271,10 @@ final class AppState {
             await captureInsertionTargetAppAndContext(target: target, useFrontmost: false)
             await reactivateInsertionTargetIfNeeded()
             try Task.checkCancellation()
-            guard !isShuttingDown else { return }
+            guard !isShuttingDown else {
+                recoveryStore.release(id: saved.id)
+                return
+            }
             recoveringEntryID = nil
             await beginRecording(engine: engine, mode: .handsFreeToggle)
         } catch {

--- a/Dictate AnywhereTests/DictationContinuationTests.swift
+++ b/Dictate AnywhereTests/DictationContinuationTests.swift
@@ -363,6 +363,26 @@ final class DictationContinuationTests: XCTestCase {
         XCTAssertEqual(engine.events, ["start", "cancel"])
         XCTAssertEqual(app.status, .idle)
     }
+
+    func testShutdownPreventsQueuedMicrophoneStartup() async throws {
+        let engineChoice = Settings.shared.engineChoice
+        defer { Settings.shared.engineChoice = engineChoice }
+        Settings.shared.engineChoice = .appleSpeech
+        let engine = ContinuationTestEngine()
+        let engineCancelled = expectation(description: "engine cancelled")
+        engine.onCancel = { engineCancelled.fulfill() }
+        let app = app(engine: engine)
+        engine.onSetSessionContextualVocabulary = { [weak app] in
+            engine.onSetSessionContextualVocabulary = nil
+            Task { await app?.shutdown() }
+        }
+
+        await app.startDictation()
+        await fulfillment(of: [engineCancelled], timeout: 1)
+
+        XCTAssertEqual(engine.events, ["cancel"])
+        XCTAssertEqual(app.status, .idle)
+    }
 }
 
 @MainActor
@@ -381,6 +401,7 @@ private final class ContinuationTestEngine: TranscriptionEngine {
     var onRestore: (() -> Void)?
     var onStart: (() -> Void)?
     var onCancel: (() -> Void)?
+    var onSetSessionContextualVocabulary: (() -> Void)?
     var suspendRestore = false
     var suspendStart = false
     private var pendingStop: CheckedContinuation<String, Never>?
@@ -388,6 +409,9 @@ private final class ContinuationTestEngine: TranscriptionEngine {
     private var pendingStart: CheckedContinuation<Void, Never>?
     func levelSamples(count: Int) -> [Float] { [] }
     func prepare() async throws { isReady = true }
+    func setSessionContextualVocabulary(_ vocabulary: [String]) {
+        onSetSessionContextualVocabulary?()
+    }
     func startRecording(deviceID: AudioDeviceID?) async throws {
         events.append("start")
         if suspendStart {

--- a/Dictate AnywhereTests/DictationContinuationTests.swift
+++ b/Dictate AnywhereTests/DictationContinuationTests.swift
@@ -309,8 +309,10 @@ final class DictationContinuationTests: XCTestCase {
 
         let stopping = Task { await app.stopDictation() }
         await fulfillment(of: [recognitionBegan], timeout: 1)
+        let processingCancelled = expectation(description: "processing cancelled")
+        engine.onStopCancellation = { processingCancelled.fulfill() }
         let shuttingDown = Task { await app.shutdown() }
-        await Task.yield()
+        await fulfillment(of: [processingCancelled], timeout: 1)
         engine.finishPendingStop()
         await stopping.value
         await shuttingDown.value
@@ -335,6 +337,7 @@ final class DictationContinuationTests: XCTestCase {
 
         XCTAssertEqual(engine.events, ["restore", "cancel"])
         XCTAssertEqual(app.status, .idle)
+        XCTAssertNoThrow(try store.remove(id: entry.id))
     }
 
     func testShutdownDrainsPendingMicrophoneStartup() async throws {
@@ -349,13 +352,10 @@ final class DictationContinuationTests: XCTestCase {
 
         let starting = Task { await app.startDictation() }
         await fulfillment(of: [startupBegan], timeout: 1)
-        var shutdownCompleted = false
-        let shuttingDown = Task {
-            await app.shutdown()
-            shutdownCompleted = true
-        }
-        await Task.yield()
-        XCTAssertFalse(shutdownCompleted)
+        let engineCancelled = expectation(description: "engine cancelled")
+        engine.onCancel = { engineCancelled.fulfill() }
+        let shuttingDown = Task { await app.shutdown() }
+        await fulfillment(of: [engineCancelled], timeout: 1)
         engine.finishPendingStart()
         await starting.value
         await shuttingDown.value
@@ -377,8 +377,10 @@ private final class ContinuationTestEngine: TranscriptionEngine {
     var restoreFails = false
     var startFails = false
     var onStop: (() -> Void)?
+    var onStopCancellation: (() -> Void)?
     var onRestore: (() -> Void)?
     var onStart: (() -> Void)?
+    var onCancel: (() -> Void)?
     var suspendRestore = false
     var suspendStart = false
     private var pendingStop: CheckedContinuation<String, Never>?
@@ -400,9 +402,13 @@ private final class ContinuationTestEngine: TranscriptionEngine {
     func stopRecording() async -> String {
         events.append("stop")
         guard onStop != nil else { return stoppedText }
-        return await withCheckedContinuation { continuation in
-            pendingStop = continuation
-            onStop?()
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                pendingStop = continuation
+                onStop?()
+            }
+        } onCancel: {
+            Task { @MainActor [weak self] in self?.onStopCancellation?() }
         }
     }
     func finishPendingStop() {
@@ -417,7 +423,10 @@ private final class ContinuationTestEngine: TranscriptionEngine {
         pendingRestore?.resume(returning: restoredText)
         pendingRestore = nil
     }
-    func cancel() async { events.append("cancel") }
+    func cancel() async {
+        events.append("cancel")
+        onCancel?()
+    }
     func transcribeRecording(at url: URL) async throws -> String {
         events.append("restore")
         if restoreFails { throw TranscriptionError.engineNotReady }

--- a/Dictate AnywhereTests/DictationContinuationTests.swift
+++ b/Dictate AnywhereTests/DictationContinuationTests.swift
@@ -297,6 +297,45 @@ final class DictationContinuationTests: XCTestCase {
         XCTAssertEqual(engine.events, ["restore", "start"])
         await app.cancelDictation()
     }
+
+    func testShutdownDoesNotDeliverPendingRecognition() async throws {
+        let entry = try await savedSession()
+        let engine = ContinuationTestEngine()
+        var delivered: [String] = []
+        let app = app(engine: engine) { delivered.append($0); return .success }
+        await app.continueCancelledDictation(entry)
+        let recognitionBegan = expectation(description: "recognition began")
+        engine.onStop = { recognitionBegan.fulfill() }
+
+        let stopping = Task { await app.stopDictation() }
+        await fulfillment(of: [recognitionBegan], timeout: 1)
+        let shuttingDown = Task { await app.shutdown() }
+        await Task.yield()
+        engine.finishPendingStop()
+        await stopping.value
+        await shuttingDown.value
+
+        XCTAssertTrue(delivered.isEmpty)
+        XCTAssertTrue(Settings.shared.transcriptHistory.isEmpty)
+    }
+
+    func testShutdownPreventsPendingContinuationFromStartingMicrophone() async throws {
+        let entry = try await savedSession()
+        let engine = ContinuationTestEngine()
+        engine.suspendRestore = true
+        let app = app(engine: engine)
+        let restorationBegan = expectation(description: "restoration began")
+        engine.onRestore = { restorationBegan.fulfill() }
+
+        let continuing = Task { await app.continueCancelledDictation(entry) }
+        await fulfillment(of: [restorationBegan], timeout: 1)
+        await app.shutdown()
+        engine.finishPendingRestore()
+        await continuing.value
+
+        XCTAssertEqual(engine.events, ["restore", "cancel"])
+        XCTAssertEqual(app.status, .idle)
+    }
 }
 
 @MainActor
@@ -311,7 +350,10 @@ private final class ContinuationTestEngine: TranscriptionEngine {
     var restoreFails = false
     var startFails = false
     var onStop: (() -> Void)?
+    var onRestore: (() -> Void)?
+    var suspendRestore = false
     private var pendingStop: CheckedContinuation<String, Never>?
+    private var pendingRestore: CheckedContinuation<String, Never>?
     func levelSamples(count: Int) -> [Float] { [] }
     func prepare() async throws { isReady = true }
     func startRecording(deviceID: AudioDeviceID?) async throws {
@@ -331,10 +373,20 @@ private final class ContinuationTestEngine: TranscriptionEngine {
         pendingStop?.resume(returning: stoppedText)
         pendingStop = nil
     }
+    func finishPendingRestore() {
+        pendingRestore?.resume(returning: restoredText)
+        pendingRestore = nil
+    }
     func cancel() async { events.append("cancel") }
     func transcribeRecording(at url: URL) async throws -> String {
         events.append("restore")
         if restoreFails { throw TranscriptionError.engineNotReady }
+        if suspendRestore {
+            return await withCheckedContinuation { continuation in
+                pendingRestore = continuation
+                onRestore?()
+            }
+        }
         return restoredText
     }
 }

--- a/Dictate AnywhereTests/DictationContinuationTests.swift
+++ b/Dictate AnywhereTests/DictationContinuationTests.swift
@@ -336,6 +336,33 @@ final class DictationContinuationTests: XCTestCase {
         XCTAssertEqual(engine.events, ["restore", "cancel"])
         XCTAssertEqual(app.status, .idle)
     }
+
+    func testShutdownDrainsPendingMicrophoneStartup() async throws {
+        let engineChoice = Settings.shared.engineChoice
+        defer { Settings.shared.engineChoice = engineChoice }
+        Settings.shared.engineChoice = .appleSpeech
+        let engine = ContinuationTestEngine()
+        engine.suspendStart = true
+        let app = app(engine: engine)
+        let startupBegan = expectation(description: "microphone startup began")
+        engine.onStart = { startupBegan.fulfill() }
+
+        let starting = Task { await app.startDictation() }
+        await fulfillment(of: [startupBegan], timeout: 1)
+        var shutdownCompleted = false
+        let shuttingDown = Task {
+            await app.shutdown()
+            shutdownCompleted = true
+        }
+        await Task.yield()
+        XCTAssertFalse(shutdownCompleted)
+        engine.finishPendingStart()
+        await starting.value
+        await shuttingDown.value
+
+        XCTAssertEqual(engine.events, ["start", "cancel"])
+        XCTAssertEqual(app.status, .idle)
+    }
 }
 
 @MainActor
@@ -351,13 +378,22 @@ private final class ContinuationTestEngine: TranscriptionEngine {
     var startFails = false
     var onStop: (() -> Void)?
     var onRestore: (() -> Void)?
+    var onStart: (() -> Void)?
     var suspendRestore = false
+    var suspendStart = false
     private var pendingStop: CheckedContinuation<String, Never>?
     private var pendingRestore: CheckedContinuation<String, Never>?
+    private var pendingStart: CheckedContinuation<Void, Never>?
     func levelSamples(count: Int) -> [Float] { [] }
     func prepare() async throws { isReady = true }
     func startRecording(deviceID: AudioDeviceID?) async throws {
         events.append("start")
+        if suspendStart {
+            await withCheckedContinuation { continuation in
+                pendingStart = continuation
+                onStart?()
+            }
+        }
         if startFails { throw TranscriptionError.engineNotReady }
         recoveryCapture?.append(Array(repeating: 0.5, count: 16_000))
     }
@@ -372,6 +408,10 @@ private final class ContinuationTestEngine: TranscriptionEngine {
     func finishPendingStop() {
         pendingStop?.resume(returning: stoppedText)
         pendingStop = nil
+    }
+    func finishPendingStart() {
+        pendingStart?.resume()
+        pendingStart = nil
     }
     func finishPendingRestore() {
         pendingRestore?.resume(returning: restoredText)

--- a/Dictate AnywhereTests/PermissionLifecycleTests.swift
+++ b/Dictate AnywhereTests/PermissionLifecycleTests.swift
@@ -8,7 +8,8 @@ final class PermissionLifecycleTests: XCTestCase {
         let permissionResponse = SuspendedPermissionResponse {
             permissionRequested.fulfill()
         }
-        let appState = AppState(microphonePermissionRequester: {
+        let permissions = Permissions(statusProvider: { (false, false) })
+        let appState = AppState(permissions: permissions, microphonePermissionRequester: {
             await permissionResponse.waitForResolution()
         })
         let binding = HotkeyBinding(


### PR DESCRIPTION
### Summary

- Delay application termination until app services have shut down cleanly.
- Stop active dictation, input monitoring, permission polling, audio work, overlays, and background startup/profile tasks.
- Unload S1-mini before allowing Quit or Sparkle-triggered relaunch.
- Prevent cancelled background work from restarting services while termination is in progress.
- Make the permission lifecycle test independent of the host machine’s actual microphone permission.

### Root Cause

llama.cpp Metal residency-set teardown can abort during normal AppKit termination if S1-mini remains loaded. Sparkle relaunch follows that same termination path. This change preserves Metal acceleration while ensuring the model and dependent services are released before exit.

### Verification

- scripts/dev.sh build
- scripts/dev.sh test
- 351 tests passed
- 14 expected skips